### PR TITLE
Clean-Up Markdown Formatting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,4 +5,4 @@ rvm:
 before_script:
   - gem install awesome_bot
 script:
-  - awesome_bot README.md --allow-redirect --white-list linkedin.com,kismatic.com --allow-dupe twitter.com,github.com,youtube.com,creativecommons.org
+  - awesome_bot README.md --allow-redirect --white-list linkedin.com,kismatic.com,slideshare.net --allow-dupe twitter.com,github.com,youtube.com,creativecommons.org

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,14 +1,19 @@
-## Contributing Guidelines:
+[awesome-docker]: https://github.com/veggiemonk/awesome-docker/blob/master/CONTRIBUTING.md
+
+
+Contributing Guidelines:
+=======================================================================
 
 We appreciate and recognize all contributors.
 
-Contribution Guidelines
+
+## Contribution Guidelines
+
 * To add to the list: Submit a pull request
 * To remove from the list: Submit a pull request
 * Want to change something: Submit a pull request
 * Want to try something else: Submit a pull request
 * Don't know what to do: Submit a pull request
-
 * Each item should be limited to one link
 * The link should be the name of the package or project or website
 * Descriptions should be clear and concise (read it out loud to be sure)
@@ -16,14 +21,19 @@ Contribution Guidelines
 * If you want to add more than one link, please don't do all PR on the exact same line, it usually results in conflicts and your PR cannot be automatically merged...
 * Please contribute links to packages/projects you have used or are familiar with. This will help ensure high-quality entries.
 
-Quality standard
+
+## Quality standard
 
 To be on the list, it would be nice if entries adhere to these quality standards:
 
 * Generally useful to the community
-* Clearly "what is it" --> which category it belongs : article, video, twitter account, ...
-* Clearly stating "what is it for": mention the problem it solves. Just try your best, make it clear for the next person.
+* Clearly "what is it" --> which category it belongs : article, video, twitter account, etc.
+* Clearly stating "what is it for": mention the problem it solves. Just try your best, make it clear for the next person
 * Solves a real problem (even a small one)
-* If it is a WIP (work in progress, not safe for production), mention it. 
+* If it is a WIP (work in progress, not safe for production), mention it
 
-Abstract taken from [awesome-docker](https://github.com/veggiemonk/awesome-docker/blob/master/CONTRIBUTING.md)
+
+-----------------------------------------------------------------------
+
+
+Abstract adopted from [awesome-docker][awesome-docker].

--- a/README.md
+++ b/README.md
@@ -1,33 +1,80 @@
-# Awesome-kubernetes 
-[![Awesome](https://cdn.rawgit.com/sindresorhus/awesome/d7305f38d29fed78fa85652e3a63e154dd8e8829/media/badge.svg)](https://github.com/sindresorhus/awesome) 
+Awesome-Kubernetes
+=======================================================================
+
+[![Awesome](https://cdn.rawgit.com/sindresorhus/awesome/d7305f38d29fed78fa85652e3a63e154dd8e8829/media/badge.svg)](https://github.com/sindresorhus/awesome)
 [![Build Status](https://travis-ci.org/ramitsurana/awesome-kubernetes.svg?branch=master)](https://travis-ci.org/ramitsurana/awesome-kubernetes)
 [![License](https://img.shields.io/badge/License-CC%204.0-brightgreen.svg)](http://creativecommons.org/licenses/by-nc/4.0/)
 
-A curated list for awesome kubernetes sources Inspired by [@sindresorhus' awesome](https://github.com/sindresorhus/awesome) 
+A curated list for awesome kubernetes sources Inspired by [@sindresorhus' awesome](https://github.com/sindresorhus/awesome)
 
 ![k8](https://cloud.githubusercontent.com/assets/8342133/13547481/fcb5ffb0-e2fa-11e5-8f75-555cea5eb7b2.png)
 
 
-> "Talent wins games, but teamwork and intelligence wins championships." 
-> by Michael Jordan
+> "Talent wins games, but teamwork and intelligence wins championships."
+>
+> -- Michael Jordan
 
 Without the help from these [amazing contributors](https://github.com/ramitsurana/awesome-kubernetes/graphs/contributors),
-building this awesome-repo would never has been possible.Thank You very much guys !!
+building this awesome-repo would never has been possible, Thank You very much guys !!
 
-#### *If you see a package or project here that is no longer maintained or is not a good fit, please submit a pull request to improve this file. Thank you!*
+**If you see a package or project here that is no longer maintained or is not a good fit, please submit a pull request to improve this file. Thank you!**
 
-# What is Kubernetes ? :ship:
+
+## What is Kubernetes? :ship:
 
 > Kubernetes is an open source orchestration system for Docker containers. It handles scheduling onto nodes in a compute cluster and actively manages workloads to ensure that their state matches the users declared intentions. Using the concepts of "labels" and "pods", it groups the containers which make up an application into logical units for easy management and discovery.
 
 _Source:_ [What is Kubernetes](http://kubernetes.io/)
 
-# Roadmap: 
 
-The awesome-kubernetes will now soon be available in the form of different releases and package bundles.It means that you can 
-download the awesome kubernetes release upto a certain period of time.The release for awesome kubernetes 2015 bundle is release.Checkout the releases column for more info.Stay tuned for more updates.
+## Roadmap
 
-# Starting point:
+The awesome-kubernetes will now soon be available in the form of different releases and package bundles, It means that you can
+download the awesome kubernetes release upto a certain period of time, The release for awesome kubernetes 2015 bundle is release, Checkout the releases column for more info, Stay tuned for more updates.
+
+
+-----------------------------------------------------------------------
+
+
+Menu
+=======================================================================
+
+* [Starting Point](#starting-point)
+* [Main Resources](#main-resources)
+* [Useful Articles](#useful-articles)
+* [Related Projects](#related-projects)
+  * [Related Software](#related-software)
+    * [Hypervisor-Agnostic Docker Engine](#hypervisor-agnostic-docker-engine)
+    * [Helm Package Manager](#helm-package-manager)
+    * [Ubernetes](#ubernetes)
+    * [Fabric8](#fabric8)
+    * [kmachine](#kmachine)
+    * [spread](#spread)
+  * [Monitoring Services](#monitoring-services)
+  * [Paas Providers](#paasproviders)
+    * [OpenShift](#openshift)
+    * [Deis](#deis)
+  * [Continous Delivery](#continousdelivery)
+    * [Fabric8](#fabric8)
+* [Books](#books) :books:
+* [Slide Presentations](#slide-presentations)
+* [Videos](#videos) :tv:
+  * [Main Account](#main-account)
+  * [Other Useful videos](#other-useful-videos)
+* [Interesting Twitter Accounts](#interesting-twitter-accounts)
+* [Amazing People](#amazing-people)
+* [Connecting with Kubernetes](#connecting-with-kubernetes)
+* [Conferences](#conferences)
+* [Contributing](#contributing)
+* [License](#license)
+
+
+-----------------------------------------------------------------------
+
+
+Starting Point
+=======================================================================
+
 *A place that marks the beginning of a journey*
 
 * [Are you Ready to Manage your Infrastructure like Google?](http://www.jetstack.io/new-blog/2015/6/19/are-you-ready-to-manage-your-infrastructure-like-google-kubernetes-coming-to-a-cloud-near-you)
@@ -40,29 +87,20 @@ download the awesome kubernetes release upto a certain period of time.The releas
 * [Application Containers: Kubernetes and Docker from Scratch](http://keithtenzer.com/2015/06/01/application-containers-kubernetes-and-docker-from-scratch/) by [Keith Tenzer](https://twitter.com/keithtenzer)
 * [Learn the Kubernetes Key Concepts in 10 Minutes](http://omerio.com/2015/12/18/learn-the-kubernetes-key-concepts-in-10-minutes/) by [Omer Dawelbeit](https://twitter.com/omerio)
 
-# Menu:  
-* [Useful Articles](#useful-articles)
-* [Main Resources](#main-resources)
-* [Monitoring Services](#monitoring)
-* [Helm Package Manager](#helm-package-manager)
-* [Ubernetes](#ubernetes)
-* [fabric8](#fabric8)
-* [kmachine](#kmachine)
-* [Paas Providers](#paasproviders)
-* [Continous Delivery](#continousdelivery)
-* [Books](#books) :books:
-* [Slide Presentations](#slide-presentations)
-* [Videos](#videos) :tv:
- * [Main Account](#main-account)
- * [Useful videos](#useful-videos)
-* [Interesting Twitter Accounts](#interesting-twitter-accounts)
-* [Amazing People](#amazing-people)
-* [Connecting with Kubernetes](#connecting-with-kubernetes)
-* [Conferences](#conferences)
-* [Contributing](#contributing)
-* [License](#license)
 
-# Useful Articles:
+Main Resources
+=======================================================================
+
+*Official resources from the Kubernetes team*
+
+* [Kubernetes Documentation](http://kubernetes.io/docs/)
+* [Kubernetes Source](https://github.com/kubernetes/kubernetes/)
+* [Kubernetes Troubleshooting](http://kubernetes.io/docs/troubleshooting/)
+
+
+Other Useful Articles
+=======================================================================
+
 *A piece of writing included with others in a newspaper, magazine, or other publication*
 
 * [Kubernetes: Getting Started With a Local Deployment](http://www.jetstack.io/new-blog/2015/7/6/getting-started-with-a-local-deployment)
@@ -71,7 +109,7 @@ download the awesome kubernetes release upto a certain period of time.The releas
 *  [An Introduction to Kubernetes](https://www.digitalocean.com/community/tutorials/an-introduction-to-kubernetes) by [Justin Ellingwood](https://twitter.com/jmellingwood)
 *  [Scaling Docker with Kubernetes](http://www.infoq.com/articles/scaling-docker-with-kubernetes) by [Carlos Sanchez](https://twitter.com/csanchez)
 * [Creating a Kubernetes Cluster to Run Docker Formatted Container Images](https://access.redhat.com/articles/1353773) by [Chris Negus](https://twitter.com/linuxcricket)
-* [Containerizing Docker on Kubernetes !!](https://www.linkedin.com/pulse/containerizing-docker-kubernetes-ramit-surana) by [Ramit Surana](https://twitter.com/ramitsurana) 
+* [Containerizing Docker on Kubernetes !!](https://www.linkedin.com/pulse/containerizing-docker-kubernetes-ramit-surana) by [Ramit Surana](https://twitter.com/ramitsurana)
 * [Running Kubernetes Example on CoreOS, Part 1](https://coreos.com/blog/running-kubernetes-example-on-CoreOS-part-1/) by [Kelsey Hightower](https://twitter.com/kelseyhightower)
 * [Play With Kubernetes Quickly Using Docker](https://zwischenzugs.wordpress.com/2015/04/06/play-with-kubernetes-quickly-using-docker/)
 * [1 command to Kubernetes with Docker compose](http://sebgoa.blogspot.in/2015/04/1-command-to-kubernetes-with-docker.html) by [Sebastien Goasguen](https://twitter.com/sebgoa)
@@ -105,61 +143,48 @@ download the awesome kubernetes release upto a certain period of time.The releas
 * [Comparison of Networking Solutions for Kubernetes](http://machinezone.github.io/research/networking-solutions-for-kubernetes/)
 * [Why Docker and Google Kubernetes Are Like PaaS Done Right](https://www.sdxcentral.com/articles/news/why-docker-and-google-kubernetes-are-like-paas-done-right/2015/08/)
 
-## Main Resources:
 
-## Monitoring:
-*To maintain regular surveillance over kubernetes*
+Related Projects
+=======================================================================
 
-* [Console](https://github.com/kubernetes/dashboard):
-  It is a general purpose, web-based UI for Kubernetes clusters. It allows to manage applications running in the cluster, troubleshoot them, as well as, manage the cluster itself.
-* [Datadog](https://www.datadoghq.com/):
- Datadog is a hosted monitoring and metrics platform, with built in support for Kubernetes and Docker.  Their Kubernetes integration pulls in Docker and Kubernetes events, converts labels and pod names into tags, as well as pulls metrics from Docker and CAdvisor.  This allows you to build application dashboards and alerts that display data across pods, Nodes, and services.
-* [Heapster](https://github.com/kubernetes/heapster): 
-Heapster enables Container Cluster Monitoring and Performance Analysis.
-Heapster currently supports Kubernetes and CoreOS natively. It can be extended to support other cluster management solutions easily. Heapster collects and interprets various signals like compute resource usage, lifecycle events, etc, and exports cluster metrics via REST endpoints.
-* [Kubedash](https://github.com/kubernetes/kubedash):
-Performance analytics UI for Kubernetes Clusters.
-The goal of Kubedash is to allow the user or an administrator of a Kubernetes cluster to easily verify and understand the performance of a cluster and jobs running within it through intuitive visualizations of aggregated metrics, derived stats and event patterns. It is not intended to be a general-purpose Kubernetes UI. Instead, kubedash uses multiple sources of information to summarize and provide high-level analytic information to users and to the cluster administrator.
-* [Kube-ui](https://github.com/kubernetes/kube-ui):
- Container Cluster Manager from Google Web UI 
-* [Prometheus](http://prometheus.io):
- Prometheus is an open-source systems monitoring and alerting toolkit originally built at SoundCloud. Since its inception in 2012, many companies and organizations have adopted Prometheus, and the project has a very active developer and user community. It is now a standalone open source project and maintained independently of any company.
-* [Sysdig](http://www.sysdig.org/):
- Sysdig is open source, system-level exploration: capture system state and activity from a running Linux instance, then save,  filter and analyze. Sysdig is scriptable in Lua and includes a command line interface and a powerful interactive UI,csysdig, that runs in your terminal.
-
-## Hypervisor-agnostic Docker Engine:
-Hyper is a Hypervisor-agnostic Docker Engine that allows you to run Docker images on any hypervisor (KVM, Xen, etc.).
-Technically speaking,
-
-Hyper = Hypervisor + Kernel + Docker Image
-
-By containing applications within separate VM instances and kernel spaces, Hyper is able to offer an excellent Hardware-enforced Isolation, which is much needed in multi-tenant environments.
-
-Hyper also promises Immutable Infrastructure by eliminating the middle layer of Guest OS, along with the hassle to configure and manage them.
-
-* [Announcing Hypernetes - The Multitenant Kubernetes Distribution](https://hyper.sh/blog/post/2015/10/27/announcing-hypernetes-the-multitenant-kubernetes-distribution.html) by [Thibault Bronchain](https://twitter.com/tbronchain)
+*Kubernetes-related projects that you might find helpful*
 
 
-## Helm Package manager:
-Built by Deis and Inspired by Homebrew, apt, and npm, Helm is a tool for working with Kubernetes-powered applications.Helm makes it easy run apps and services inside Kubernetes.
+## Related Software
 
-* [Introducing Helm, The Kubernetes Package Manager](https://deis.com/blog/2015/introducing-helm-for-kubernetes)
+*Projects built to make life with Kubernetes even better, more powerful, more scalable*
 
-## Ubernetes:
+
+### [Hypernetes](https://github.com/hyperhq/hypernetes)
+
+Hypernetes is a secure, multi-tenant Kubernetes distro. Simply put,
+
+Hypernetes = Bare-metal + Hyper + Kubernetes + KeyStone + Cinder + Neutron.
+
+It envisions a future of "Container-as-a-Service without IaaS". The idea is to combine the orchestration power in Kubernetes and the runtime isolation in Hyper to build the truly secure multi-tenant CaaS platform.
+
+
+### [Helm Package Manager](https://deis.com/blog/2015/introducing-helm-for-kubernetes)
+
+Built by Deis and Inspired by Homebrew, apt, and NPM. Helm is a tool for working with Kubernetes-powered applications. Helm makes it easy run apps and services inside Kubernetes.
+
+
+### [Ubernetes](https://github.com/kubernetes/kubernetes/blob/master/docs/proposals/federation.md)
 
 A central design concept in Kubernetes to cluster Kubernetes across several regions.
 
-* [Introducing Kubernetes Cluster Federation a.k.a Ubernetes](https://github.com/kubernetes/kubernetes/blob/master/docs/proposals/federation.md)
- 
-## [Fabric8](http://fabric8.io/):
+
+### [Fabric8](http://fabric8.io/)
 
 An integrated open source DevOps and Integration Platform which works out of the box on any Kubernetes or OpenShift environment and provides Continuous Delivery, Management, ChatOps and a Chaos Monkey.
 
-## [Kmachine](https://github.com/skippbox/kmachine):
+
+### [kmachine](https://github.com/skippbox/kmachine)
 
 kmachine lets you create Docker hosts on your computer, on cloud providers, and inside your own data center. It creates servers, installs Docker on them, then configures the Docker client to talk to them just like docker-machine
 
-## [spread](https://github.com/redspread/spread):
+
+### [spread](https://github.com/redspread/spread)
 
 spread is a command line tool that builds and deploys a Docker project to a Kubernetes cluster in one command. The project's goals are to:
 
@@ -167,23 +192,57 @@ spread is a command line tool that builds and deploys a Docker project to a Kube
 - Be the fastest, simplest way to deploy Docker to production
 - Work well for a single developer or an entire team (no more broken bash scripts!)
 
-##PaaS Providers:
 
-### [Openshift](https://www.openshift.com/):
+## Monitoring Services
+
+*To maintain regular surveillance over kubernetes*
+
+* [Console](https://github.com/kubernetes/dashboard):
+  It is a general purpose, web-based UI for Kubernetes clusters. It allows to manage applications running in the cluster, troubleshoot them, as well as, manage the cluster itself.
+* [Datadog](https://www.datadoghq.com/):
+  Datadog is a hosted monitoring and metrics platform, with built in support for Kubernetes and Docker.  Their Kubernetes integration pulls in Docker and Kubernetes events, converts labels and pod names into tags, as well as pulls metrics from Docker and CAdvisor.  This allows you to build application dashboards and alerts that display data across pods, Nodes, and services.
+* [Heapster](https://github.com/kubernetes/heapster):
+  Heapster enables Container Cluster Monitoring and Performance Analysis.
+  Heapster currently supports Kubernetes and CoreOS natively. It can be extended to support other cluster management solutions easily. Heapster collects and interprets various signals like compute resource usage, lifecycle events, etc, and exports cluster metrics via REST endpoints.
+* [Kubedash](https://github.com/kubernetes/kubedash):
+  Performance analytics UI for Kubernetes Clusters.
+  The goal of Kubedash is to allow the user or an administrator of a Kubernetes cluster to easily verify and understand the performance of a cluster and jobs running within it through intuitive visualizations of aggregated metrics, derived stats and event patterns. It is not intended to be a general-purpose Kubernetes UI. Instead, kubedash uses multiple sources of information to summarize and provide high-level analytic information to users and to the cluster administrator.
+* [Kube-ui](https://github.com/kubernetes/kube-ui):
+  Container Cluster Manager from Google Web UI
+* [Prometheus](http://prometheus.io):
+  Prometheus is an open-source systems monitoring and alerting toolkit originally built at SoundCloud. Since its inception in 2012, many companies and organizations have adopted Prometheus, and the project has a very active developer and user community. It is now a standalone open source project and maintained independently of any company.
+* [Sysdig](http://www.sysdig.org/):
+  Sysdig is open source, system-level exploration: capture system state and activity from a running Linux instance, then save,  filter and analyze. Sysdig is scriptable in Lua and includes a command line interface and a powerful interactive UI, csysdig, that runs in your terminal.
+
+
+## PaaS Providers
+
+*Kubernetes Platform as a Service providers*
+
+
+### [OpenShift](https://www.openshift.com/)
 
 OpenShift is Red Hat's Platform-as-a-Service (PaaS) that allows developers to quickly develop, host, and scale applications in a cloud environment. With OpenShift you have a choice of offerings, including online, on premise, and open source project options.
 
-###[Deis](http://deis.io/):
+
+### [Deis](http://deis.io/)
 
 Deis (pronounced DAY-iss) is an open source PaaS that makes it easy to deploy and manage applications on your own servers. Deis builds upon Docker and CoreOS to provide a lightweight PaaS with a Heroku-inspired workflow.
 
-## Continous Delivery:
 
-###[Fabric8](http://fabric8.io):
+## Continous Delivery
 
-Fabric8 DevOps provides a completely integrated open source DevOps platform which works out of the box on any Kubernetes or OpenShift environment.The entire platform is modular and based on microservices so you can use as much or as little of Fabric8 DevOps as you wish!
+*Build-test-deploy automated workflow software designed to make production environments more stable and life better for engineers*
 
-## Books:  
+
+### [Fabric8](http://fabric8.io)
+
+Fabric8 DevOps provides a completely integrated open source DevOps platform which works out of the box on any Kubernetes or OpenShift environment, The entire platform is modular and based on microservices so you can use as much or as little of Fabric8 DevOps as you wish!
+
+
+Books
+=======================================================================
+
 *A written or printed work consisting of pages glued or sewn together along one side and bound in covers that provide
 us with information*
 
@@ -191,7 +250,10 @@ us with information*
 * [Docker and Kubernetes Under the Hood](http://item.jd.com/11757034.html) (Chinese) by [Harry Zhang](https://twitter.com/resouer), Jianbo Sun and ZJU SEL lab
 * [Kubernetes: Scheduling the Future at Cloud Scale](http://www.oreilly.com/webops-perf/free/kubernetes.csp) by [Dave K. Rensin](http://www.linkedin.com/in/drensin)
 
-## Slide Presentations:
+
+Slide Presentations
+=======================================================================
+
 *A slide is a single page of a presentation created with software such as PowerPoint or OpenOffice Impress.*
 
 * [Architecture Overview](http://www.slideshare.net/enakai/architecture-overview-kubernetes-with-red-hat-enterprise-linux-71) by [enakai00](https://twitter.com/enakai00/)
@@ -206,17 +268,22 @@ us with information*
 * [Network oriented Kubernetes intro](http://www.slideshare.net/salv_orlando/network-oriented-kubernetes-intro) by [Salv Orlando](https://twitter.com/taturiello)
 * [Zero downtime-java-deployments-with-docker-and-kubernetes](http://www.slideshare.net/ArjanSchaaf/zero-downtimejavadeploymentswithdockerandkubernetes) by [Arjan Schaaf](https://www.linkedin.com/in/arjanschaaf)
 * [Kubernetes and CoreOS @ Athens Docker meetup](http://www.slideshare.net/mistio/kubernetes-and-coreos-athens-docker-meetup) by [Mist.io](https://twitter.com/mist_io)
- 
 
-## Videos:      
+
+Videos
+=======================================================================
+
 *A recording of moving visual images made digitally or on videotape.*
 
 
-### Main Account:
+### Main Account
+
 * [Google Developers](https://www.youtube.com/channel/UC_x5XG1OV2P6uZZ5FSM9Ttw)
 * [Kubernetes](https://www.youtube.com/channel/UCZ2bu0qutTOM0tHYa_jkIwg)
 
-### Useful Videos:
+
+### Other Useful Videos
+
 * [Google I/O 2014 - Containerizing the Cloud with Docker on Google Cloud Platform](https://www.youtube.com/watch?v=tsk0pWf4ipw) by [Google Developers](https://www.youtube.com/channel/UC_x5XG1OV2P6uZZ5FSM9Ttw)
 * [Container Orchestration using CoreOS and Kubernetes](https://www.youtube.com/watch?v=tA8XNVPZM2w) by [Kelsey Hightower](https://twitter.com/kelseyhightower)
 * [A Technical Overview of Kubernetes](https://www.youtube.com/watch?v=WwBdNXt6wO4) by [Bredan Burns](https://twitter.com/brendandburns)
@@ -228,9 +295,10 @@ us with information*
 * [DevNation 2015 - Paul Bakker - Kubernetes: Beyond the basics](https://youtu.be/MuazGHiiGmA) by [Paul Bakker](https://twitter.com/pbakker)
 
 
-## Interesting Twitter Accounts:
+Interesting Twitter Accounts
+=======================================================================
 
-####*"Twitter is quick, it’s easy to communicate on, and is a very valuable social channel for a brand or business if you use it to its full potential.By following these news aggregators, rolling news channels, and companies, you can get the inside scoop of a story long before it hits the mainstream news outlets."*
+*Twitter is quick, it’s easy to communicate on, and is a very valuable social channel for a brand or business if you use it to its full potential, By following these news aggregators, rolling news channels, and companies, you can get the inside scoop of a story long before it hits the mainstream news outlets.*
 
 
 * [Kubernetes](https://twitter.com/kubernetesio)
@@ -245,20 +313,24 @@ us with information*
 * [KubeFacts](https://twitter.com/kubefacts)
 * [Skippbox](https://twitter.com/skippbox)
 
-## Amazing People:
 
-* [Bredan Burns](https://twitter.com/brendandburns),Senior Staff Software Engineer at Google
-* [Kelsey Hightower](https://twitter.com/kelseyhightower),Staff Developer Advocate at Google
-* [Arun Gupta](https://twitter.com/arungupta),Vice President, Developer Relations at Couchbase
-* [Carlos Sanchez](https://www.twitter.com/csanchez),Senior Software Engineer,CloudBees
-* [Satnam Singh](https://www.twitter.com/satnamsingh),Software Engineer at Facebook
-* [Joseph Jacks](https://twitter.com/asynchio),VP, Technology Strategy at Kismatic, Inc
-* [Joe Beda](https://twitter.com/jbeda),Co-founder and Technical Lead for Kubernetes
-* [Patrick Reilly](https://twitter.com/preillyme),CEO at Kismatic, Inc. / Advisor at Mesosphere, Inc
-* [Brandon Philips](https://twitter.com/BrandonPhilips),CTO at CoreOS
+Amazing People
+=======================================================================
+
+* [Bredan Burns](https://twitter.com/brendandburns), Senior Staff Software Engineer at Google
+* [Kelsey Hightower](https://twitter.com/kelseyhightower), Staff Developer Advocate at Google
+* [Arun Gupta](https://twitter.com/arungupta), Vice President, Developer Relations at Couchbase
+* [Carlos Sanchez](https://www.twitter.com/csanchez), Senior Software Engineer, CloudBees
+* [Satnam Singh](https://www.twitter.com/satnamsingh), Software Engineer at Facebook
+* [Joseph Jacks](https://twitter.com/asynchio), VP, Technology Strategy at Kismatic, Inc
+* [Joe Beda](https://twitter.com/jbeda), Co-founder and Technical Lead for Kubernetes
+* [Patrick Reilly](https://twitter.com/preillyme), CEO at Kismatic, Inc. / Advisor at Mesosphere, Inc
+* [Brandon Philips](https://twitter.com/BrandonPhilips), CTO at CoreOS
 
 
-## Connecting with Kubernetes:
+Connecting with Kubernetes
+=======================================================================
+
 * [Freenode](http://webchat.freenode.net/?channels=google-containers)
 * [Twitter](https://twitter.com/kubernetesio)
 * [Google +](https://plus.google.com/u/0/b/116512812300813784482/116512812300813784482)
@@ -267,7 +339,10 @@ us with information*
 * [Mailing List](https://groups.google.com/forum/#!forum/google-containers)
 * [Newsletter](https://kismatic.com/community/introducing-kubernetes-weekly-news/) by [Kismatic](https://kismatic.com/)
 
-## Conferences:
+
+Conferences
+=======================================================================
+
 *Some must to go and attend conferences on kubernetes*
 
 * [Kubecon](https://kubecon.io/)
@@ -276,15 +351,18 @@ us with information*
 * [Docker Con](http://dockercon.com)
 * [Devoxx](http://devoxx.com)
 
-## Contributing:
+
+Contributing
+=======================================================================
+
 Contributions are most welcome!
 
 This list is just getting started, please contribute to make it super awesome.
 
 Check out the [Contributing Guidelines](https://github.com/ramitsurana/awesome-kubernetes/blob/master/CONTRIBUTING.md).
 
-## License:
 
-  <a rel="license" href="http://creativecommons.org/licenses/by-nc/4.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by-nc/4.0/88x31.png" /></a><br /><span xmlns:dct="http://purl.org/dc/terms/" href="http://purl.org/dc/dcmitype/InteractiveResource" property="dct:title" rel="dct:type">awesome-kubernetes</span> by <a xmlns:cc="http://creativecommons.org" href="http://www.linkedin.com/in/ramitsurana" property="cc:attributionName" rel="cc:attributionURL">Ramit Surana</a> is licensed under a <a rel="license" href="http://creativecommons.org/licenses/by-nc/4.0/">Creative Commons Attribution-NonCommercial 4.0 International License</a>.
+License
+=======================================================================
 
-
+<a rel="license" href="http://creativecommons.org/licenses/by-nc/4.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by-nc/4.0/88x31.png" /></a><br /><span xmlns:dct="http://purl.org/dc/terms/" href="http://purl.org/dc/dcmitype/InteractiveResource" property="dct:title" rel="dct:type">awesome-kubernetes</span> by <a xmlns:cc="http://creativecommons.org" href="http://www.linkedin.com/in/ramitsurana" property="cc:attributionName" rel="cc:attributionURL">Ramit Surana</a> is licensed under a <a rel="license" href="http://creativecommons.org/licenses/by-nc/4.0/">Creative Commons Attribution-NonCommercial 4.0 International License</a>.


### PR DESCRIPTION
Over multiple commits, it's clear that formatting has suffered. This
commit normalizes headers, links to resoruces, and Markdown formatting.

This commit adds type-1 headers for top-level menu links. To better
segment Related Projects, this commit segments related projects into
type-2 headers for Related Software, Monitoring Services, PaaS
Providers, and Continuous Delivery. I found it hard to figure out
where everything fit when I first read, so I hope this helps clear
up the hierarchy of those sections.

No new project links have been added, but some 404 links have been
removed, a failing Travis test has been fixed (slideshare.net links),
and official Kubernetes links have been added to the previously-empty
Main Resources section. I hope this helps.