### PR TITLE
Whitelist and debug new links

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,4 +5,4 @@ rvm:
 before_script:
   - gem install awesome_bot
 script:
-  - awesome_bot README.md --allow-redirect --white-list linkedin.com,kismatic.com,slideshare.net --allow-dupe twitter.com,github.com,youtube.com,creativecommons.org
+  - awesome_bot README.md --allow-redirect --white-list linkedin.com,kismatic.com,slideshare.net,research.google.com --allow-dupe twitter.com,github.com,youtube.com,creativecommons.org

--- a/README.md
+++ b/README.md
@@ -28,8 +28,9 @@ building this awesome-repo would never has been possible, Thank You very much gu
 
 _Source:_ [What is Kubernetes](http://kubernetes.io/)
 
+
 ## History:
- 
+
 **Kubernetes is known to be a descendant of Google's system BORG**
 
 > The first unified container-management system developed at Google was the system we internally call Borg.
@@ -37,7 +38,7 @@ It was built to manage both long-running services and batch jobs, which had prev
 systems: Babysitter and the Global Work Queue. The latter’s architecture strongly influenced Borg, but was focused on
 batch jobs; both predated Linux control groups.
 
-_Source:_ [Kubernetes Past](http://http://research.google.com/pubs/archive/44843.pdf)
+_Source:_ [Kubernetes Past](http://research.google.com/pubs/archive/44843.pdf)
 
 
 ## Roadmap
@@ -367,7 +368,7 @@ Connecting with Kubernetes
 * [Mailing List](https://groups.google.com/forum/#!forum/google-containers)
 * [Newsletter](https://kismatic.com/community/introducing-kubernetes-weekly-news/) by [Kismatic](https://kismatic.com/)
 
-Companies 
+Companies
 =======================================================================
 
 *A list of companies supporting Kubernetes*


### PR DESCRIPTION
This commit fixes the broken Travis tests by whitelisting new linked
domains and debugging a broken Google research link about the Borg
project.