### PR TITLE
Add Kubernetes monitoring guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ Useful Articles
 * [Kubernetes Authentication - OpenID Connect](http://www.devoperandi.com/kubernetes-authentication-openid-connect/) by [Michael Ward](https://twitter.com/DevoperandI)
 * [Logging - Kafka topic by namespace](http://www.devoperandi.com/logging-kafka-topic-by-kubernetes-namespace/) by [Michael Ward](https://twitter.com/DevoperandI)
 * [Achieving CI/CD with Kubernetes](http://theremotelab.com/blog/achieving-ci-cd-with-k8s/) by [Ramit Surana](https://twitter.com/ramitsurana)
-* [Kubernetes Monitoring Guide](https://www.datadoghq.com/blog/monitoring-kubernetes-era/) by [
+* [Kubernetes Monitoring Guide](https://www.datadoghq.com/blog/monitoring-kubernetes-era/) by [JM 
 Saponaro](http://github.com/JayJayM)
 
 

--- a/README.md
+++ b/README.md
@@ -178,7 +178,8 @@ Useful Articles
 * [Kubernetes Authentication - OpenID Connect](http://www.devoperandi.com/kubernetes-authentication-openid-connect/) by [Michael Ward](https://twitter.com/DevoperandI)
 * [Logging - Kafka topic by namespace](http://www.devoperandi.com/logging-kafka-topic-by-kubernetes-namespace/) by [Michael Ward](https://twitter.com/DevoperandI)
 * [Achieving CI/CD with Kubernetes](http://theremotelab.com/blog/achieving-ci-cd-with-k8s/) by [Ramit Surana](https://twitter.com/ramitsurana)
-* [Kubernetes Monitoring Guide[(https://www.datadoghq.com/blog/monitoring-kubernetes-era/) by [JM Saponaro](http://github.com/JayJayM)
+* [Kubernetes Monitoring Guide](https://www.datadoghq.com/blog/monitoring-kubernetes-era/) by [
+Saponaro](http://github.com/JayJayM)
 
 
 Cloud Providers

--- a/README.md
+++ b/README.md
@@ -178,6 +178,8 @@ Useful Articles
 * [Kubernetes Authentication - OpenID Connect](http://www.devoperandi.com/kubernetes-authentication-openid-connect/) by [Michael Ward](https://twitter.com/DevoperandI)
 * [Logging - Kafka topic by namespace](http://www.devoperandi.com/logging-kafka-topic-by-kubernetes-namespace/) by [Michael Ward](https://twitter.com/DevoperandI)
 * [Achieving CI/CD with Kubernetes](http://theremotelab.com/blog/achieving-ci-cd-with-k8s/) by [Ramit Surana](https://twitter.com/ramitsurana)
+* [Kubernetes Monitoring Guide[(https://www.datadoghq.com/blog/monitoring-kubernetes-era/) by [JM Saponaro](http://github.com/JayJayM)
+
 
 Cloud Providers
 =======================================================================


### PR DESCRIPTION
Hello, Datadog recently released a 3 part kubernetes monitoring guide. It's monitoring tool agnostic and focuses on the key metrics and ways to access them for kubernetes. I thought it would be a good fit here.

Part 1: Monitoring in the Kubernetes era
https://www.datadoghq.com/blog/monitoring-kubernetes-era/

Part 2: Monitoring Kubernetes performance metrics
https://www.datadoghq.com/blog/monitoring-kubernetes-performance-metrics/

Part 3: How to collect and graph Kubernetes metrics
https://www.datadoghq.com/blog/how-to-collect-and-graph-kubernetes-metrics/