### PR TITLE
README: add CoreOS Tectonic as an enterprise product

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ Menu
 * [Persistent Volume Providers](#persistent-volume-providers)
 * [Related Projects](#related-projects)
   * [Related Software](#related-software)
+* [Enterprise Kubernetes Products](#enterprise-kubernetes-products)
 * [Monitoring Services](#monitoring-services)
 * [Paas Providers](#paasproviders)    
 * [Continuous Delivery](#continuous-delivery)
@@ -285,6 +286,9 @@ Related Projects
 * [Sysdig Monitoring](https://www.sysdig.com/)
 * [Weave Scope](https://www.weave.works/products/weave-scope/)
 
+## Enterprise Kubernetes Products
+
+* [CoreOS Tectonic](https://tectonic.com)
 
 ## PaaS Providers
 


### PR DESCRIPTION
I am adding an Enterprise Product category as it is sort of between a
PaaS and just using open source Kubernetes.

The first entry is CoreOS Tectonic which builds on top of pure upstream
Kubernetes and integrates a number of features like self-driving
automated updates, identity, and more.

https://coreos.com/tectonic