### PR TITLE
Move openshift to the Enterprise category

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,7 +296,7 @@ Related Projects
 ## Enterprise Kubernetes Products
 
 * [CoreOS Tectonic](https://tectonic.com)
-* [OpenShift](https://www.openshift.com/)
+* [OpenShift - Container Platform](https://www.openshift.com/container-platform/index.html)
 
 ## PaaS Providers
 
@@ -307,6 +307,7 @@ Related Projects
 * [WSO2](http://wso2.com)
 * [Rancher](http://rancher.com/running-kubernetes-aws-rancher/)
 * [Kumoru](http://kumoru.io/)
+* [Open Shift Origin](https://www.openshift.org/)
 
 ## Continuous Delivery
 
@@ -456,6 +457,7 @@ Related Projects
 * [Platform9](https://platform9.com/)
 * [Gravitational](https://github.com/gravitational)
 * [KCluster](https://kcluster.io/)
+* [OpenShift Online](https://www.openshift.com/devpreview/index.html)
 
 ## Load balancing
 

--- a/README.md
+++ b/README.md
@@ -296,12 +296,12 @@ Related Projects
 ## Enterprise Kubernetes Products
 
 * [CoreOS Tectonic](https://tectonic.com)
+* [OpenShift](https://www.openshift.com/)
 
 ## PaaS Providers
 
 *Kubernetes Platform as a Service providers*
 
-* [OpenShift](https://www.openshift.com/)
 * [Deis Workflow](https://deis.com/)
 * [Gondor/Kel]
 * [WSO2](http://wso2.com)


### PR DESCRIPTION
It is the same reasoning as Tectonic. They provide PaaS and enterprise support.
cc @philips what do you think?