### PR TITLE
Add Archon and Kube-Aliyun

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ Installers
 * [Juju](https://jujucharms.com/canonical-kubernetes) - Ubuntu - Cloud Agnostique - [Apache-2.0](https://github.com/juju-solutions/bundle-canonical-kubernetes/blob/master/LICENSE)
 * [Terraform](https://github.com/kz8s/tack) - CoreOS - AWS - [MIT](https://github.com/kz8s/tack/blob/master/LICENSE)
 * [Supergiant](http://supergiant.io/) - CoreOS - Cloud Agnostique - [Apache-2.0](https://github.com/supergiant/supergiant/blob/master/LICENSE)
+* [Archon](https://github.com/kubeup/archon) - OS Agnostique - Cloud Agnostique - [Apache-2.0](https://github.com/kubeup/archon/blob/master/LICENSE)
 
 Main Resources
 =======================================================================
@@ -283,6 +284,7 @@ Persistent Volume Providers
 * [OpenStack Cinder](https://wiki.openstack.org/cinder)
 * [CephRBD](http://ceph.com/ceph-storage/block-storage/)
 * [QuoByte](https://www.quobyte.com/)
+* [Kube-Aliyun](https://github.com/kubeup/kube-aliyun)
 
 Related Projects
 =======================================================================
@@ -302,6 +304,7 @@ Related Projects
 * [Kubernetes Ec2 Autoscaler](https://github.com/openai/kubernetes-ec2-autoscaler)
 * [Kubeform](https://capgemini.github.io/kubeform/)
 * [kube-openvpn](https://github.com/pieterlange/kube-openvpn)
+* [Archon](https://github.com/kubeup/archon) 
 * [Client Libraries](https://github.com/kubernetes/community/blob/master/contributors/devel/client-libraries.md)
 
 ## Package Managers


### PR DESCRIPTION
Archon is a cloud operator and Kubernetes extension that can be used to not only install Kubernetes, but also scale and provision nodes.

Kube-Aliyun is an out-of-tree cloud provider and controllers for the Biggest cloud in China AliCloud/Aliyun. It provides support for LB, Routes, Volumes and also PV provisioning.

Thanks very much.