### PR TITLE
Add Linen CNI plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -449,6 +449,7 @@ Projects
 * [OpenVSwitch](http://openvswitch.org/)
 * [Kube-router](http://github.com/cloudnativelabs/kube-router)
 * [Cilium](https://github.com/cilium/cilium)
+* [Linen](https://github.com/John-Lin/linen-cni)
 
 ## Service mesh
 


### PR DESCRIPTION
## What is it
Linen is a network plugin and it respect CNI SPEC to create a overlay network in kubernetes.

## What is it for
Linen CNI is for overlay networks with Open vSwitch. It focuses on  SDN/OpenFlow network and supports for adding SDN controller such as ONOS, Ryu and OpenDaylight by configuring network configuration. Linen CNI follows the document (https://kubernetes.io/docs/admin/ovs-networking/) setup with VxLAN. 

The distinguish between ovs-kubernetes and linen please check https://github.com/John-Lin/linen-cni#should-i-use-this-or-ovn-kubernetes

This is a experimental project and try to reduce manual setup by commands with Open vSwitch.