### PR TITLE
Add kube-prompt in API/CLI adaptors

### DIFF
--- a/README.md
+++ b/README.md
@@ -486,6 +486,7 @@ Projects
 
 ## API/CLI adaptors
 
+* [kube-prompt](https://github.com/c-bata/kube-prompt) An interactive kubernetes client featuring auto-complete using go-prompt.
 * [Kube-shell](https://github.com/cloudnativelabs/kube-shell) An integrated shell for working with the Kubernetes CLI
 * [Kubebot](https://github.com/harbur/kubebot)
 * [kubectx](https://github.com/ahmetb/kubectx) - switch between clusters on kubectl


### PR DESCRIPTION
Hi!
Yesterday, I published kube-prompt.
https://github.com/c-bata/kube-prompt

This is similar with kube-shell (written in python and python-prompt-toolkit).
But, kube-prompt is built with golang and [go-prompt - golang porting of python-prompt-toolkit](https://github.com/c-bata/go-prompt).
So it can generate multi-platform binary.

I hope you like kube-prompt.