### PR TITLE
Add kompose and kubeval to YAML/JSON Config. Fix section's anchor id value.

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ Menu
 * [Big Data](#big-data)
 * [Service Discovery](#service-discovery)
 * [Operating System](#operating-system)
-* [YAML/JSON Config](#yaml/json-config)
+* [YAML/JSON Config](#yamljson-config)
 * [Tuning](#tuning)
 * [Raspberry Pi](#raspberry-pi)
 * [Books](#books) :books:
@@ -571,6 +571,8 @@ Projects
 ## YAML/JSON Config
 
 * [Kube.libsonnet](https://github.com/heptio/kube.libsonnet) - Currently Unstable
+* [kompose](https://github.com/kubernetes/kompose)
+* [kubeval](https://github.com/garethr/kubeval)
 
 ## Tuning
 


### PR DESCRIPTION
This PR adds Kubernetes' kompose and Justin Garrison's kubeval to the section of YAML/JSON Config. Additionally, it fixes the section's anchor id value (navigating to the section from the ToC was broken).