### PR TITLE
Add k8s-svc-proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -368,6 +368,7 @@ Projects
 * [Client Libraries](https://github.com/kubernetes/community/blob/master/contributors/devel/client-libraries.md)
 * [Kubic-Project](https://github.com/kubic-project)
 * [Telepresence](https://www.telepresence.io) Locally develop/debug services against a remote Kubernetes cluster
+* [k8s-svc-proxy](https://github.com/ryuheechul/k8s-svc-proxy)
 
 ## Package Managers
 


### PR DESCRIPTION
k8s-svc-proxy: it's a kind of like port-forwarding k8s services to your local machine.