### PR TITLE
Update links for Platform9 and Gravitational under managed k8s

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,8 +242,8 @@ Useful Articles
 Managed Kubernetes
 =======================================================================
 
-  - [Platform9](https://github.com/platform9)
-  - [Gravitational](https://github.com/gravitational)
+  - [Platform9](https://platform9.com)
+  - [Gravitational](https://gravitational.com/)
   - [OpenShift Online](https://www.openshift.com/devpreview/index.html)
   - [Eldarion Cloud](http://eldarion.cloud/)
   - [StackPoint Cloud](https://stackpointcloud.com/)

--- a/README.md
+++ b/README.md
@@ -242,7 +242,7 @@ Useful Articles
 Managed Kubernetes
 =======================================================================
 
-  - [Platform9](https://platform9.com)
+  - [Platform9](http://platform9.com)
   - [Gravitational](https://gravitational.com/)
   - [OpenShift Online](https://www.openshift.com/devpreview/index.html)
   - [Eldarion Cloud](http://eldarion.cloud/)


### PR DESCRIPTION
For the consistency purpose under section `Managed Kubernetes`, I have updated links for _Platform9_ and _Gravitational_.