### PR TITLE
Suggest to include PowerfulSeal in the list

### DIFF
--- a/README.md
+++ b/README.md
@@ -443,6 +443,7 @@ Projects
 * [kube-monkey](https://github.com/asobti/kube-monkey)
 * [k8s-testsuite](https://github.com/mrahbar/k8s-testsuite) - Helm chart for network and loadtesting of a Kubernetes cluster
 * [Test-Infra](https://github.com/kubernetes/test-infra)
+* [PowerfulSeal](https://github.com/bloomberg/powerfulseal) - kills targeted pods and machines to test your software reliability
 
 ## Continuous Delivery
 


### PR DESCRIPTION
I would like to suggest to include [PowerfulSeal](https://github.com/bloomberg/powerfulseal) in the list:

> __PowerfulSeal__ adds chaos to your Kubernetes clusters, so that you can detect problems in your systems as early as possible. It kills targeted pods and takes VMs up and down.

Full disclosure: I'm the main contributor, and I presented the tool last week at [Kubecon 2017 North America](https://events.linuxfoundation.org/events/kubecon-and-cloudnativecon-north-america/program/schedule)

Tell me what you think :-)