### PR TITLE
rename GKE, and clarify birthday

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ _Source:_ [Kubernetes Past](http://research.google.com/pubs/archive/44843.pdf)
 
 ## Date of Birth:
 
-Kubernetes celebrates its birthday every year on 21st July.The project was born in the year 2015.
+Kubernetes celebrates its birthday every year on 21st July. Kubernetes 1.0 was released on July 21 2015, after being first announced to the public at [Dockercon in June 2014](https://www.youtube.com/watch?v=YrxnVKZeqK8).
 
 ## Roadmap
 
@@ -299,7 +299,7 @@ Managed Kubernetes
   ### [Public/Private Cloud](#publicprivate-cloud)
 
    - [GCE](https://cloud.google.com/compute/) - Google Compute Engine [default]
-   - [GKE](https://cloud.google.com/container-engine/) - Google Container Engine
+   - [GKE](https://cloud.google.com/container-engine/) - Google Kubernetes Engine
    - [AWS](http://aws.amazon.com/ec2) - Amazon EC2
    - [Azure](https://azure.microsoft.com/en-in/) - Microsoft Azure
    - [Vsphere](http://www.vmware.com/products/vsphere.html) - VMWare VSphere


### PR DESCRIPTION
The referenced birthday was the launch of Kubernetes 1.0: http://blog.kubernetes.io/2016/07/happy-k8sbday-1.html