### PR TITLE
remove kron scheduler since its part of k8s core now

### DIFF
--- a/README.md
+++ b/README.md
@@ -517,7 +517,6 @@ Projects
 * [Scheduler](https://github.com/kelseyhightower/scheduler) - Cost based scheduler
 * [Sticky Node Scheduler](https://github.com/philipn/kubernetes-sticky-node-scheduler)
 * [ksched](https://github.com/coreos/ksched) - Experimental flow based scheduler
-* [kronjob](https://github.com/Eneco/kronjob) - Recurring jobs
 * [escheduler](https://github.com/agonzalezro/escheduler) - Written in elixir
 * [bashScheduler](https://github.com/rothgar/bashScheduler) - Written in bash
 


### PR DESCRIPTION
the scheduler is not maintained anymore and points simply to k8s CronJob docs