### PR TITLE
add thesus

### DIFF
--- a/README.md
+++ b/README.md
@@ -644,6 +644,7 @@ Projects
 * [Konfd](https://github.com/kelseyhightower/konfd)
 * [kenv](https://github.com/thisendout/kenv)
 * [kubediff](https://github.com/weaveworks/kubediff)
+* [thesus](https://github.com/heptiolabs/theseus) - A command-line utility and importable package for comparing sets of Kubernetes objects
 * [Habitat](http://www.habitat.sh/docs/best-practices/#kubernetes)
 * [Puppet](http://forge.puppet.com/garethr/kubernetes/readme)
 * [Ansible](http://docs.ansible.com/ansible/kubernetes_module.html)


### PR DESCRIPTION
Theseus is a command-line tool for comparing sets of Kubernetes objects. It reads object definitions from a running cluster, an Ark backup file, or a local directory, and performs a comparison to another source of object definitions. Theseus provides reports of which objects are in the first source only, the second source only, and both. Additionally, for objects that are in both, it performs a line-by-line comparison of the object definitions, which it outputs to stdout with highlighting, and to a text file.