### PR TITLE
Eventrouter

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ Menu
   * [Jenkins](#jenkins)
 * [Projects](#projects)
   * [Related Software](#related-software)
+* [Cluster Addons](#cluster-addons)
 * [Monitoring Services](#monitoring-services)
 * [Testing](#testing)
 * [Continuous Delivery](#continuous-delivery)
@@ -405,6 +406,9 @@ Projects
 
 *Kubernetes-related projects that you might find helpful*
 
+## Cluster Addons
+
+* [Ark](https://github.com/heptio/ark) - utility for managing disaster recovery, specifically for your Kubernetes cluster resources and persistent volumes.
 
 ## Related Software
 

--- a/README.md
+++ b/README.md
@@ -409,6 +409,7 @@ Projects
 ## Cluster Addons
 
 * [Ark](https://github.com/heptio/ark) - utility for managing disaster recovery, specifically for your Kubernetes cluster resources and persistent volumes.
+* [eventrouter](https://github.com/heptiolabs/eventrouter) - simple introspective kubernetes service that forwards events to a specified sink.
 
 ## Related Software
 


### PR DESCRIPTION
This repository contains a simple event router for the Kubernetes project. The event router serves as an active watcher of event resource in the kubernetes system, which takes those events and pushes them to a user specified sink. This is useful for a number of different purposes, but most notably long term behavioral analysis of your workloads running on your kubernetes cluster.

