### PR TITLE
add eventrouter

### DIFF
--- a/README.md
+++ b/README.md
@@ -439,6 +439,7 @@ Projects
 
 * [Console](https://github.com/kubernetes/dashboard)
 * [Datadog](http://www.datadoghq.com/)
+* [eventrouter](https://github.com/heptiolabs/eventrouter) - simple introspective kubernetes service that forwards events to a specified sink.
 * [Grafana Kubernetes App](https://github.com/grafana/kubernetes-app)
 * [Heapster](https://github.com/kubernetes/heapster)
 * [Kubebox](https://github.com/astefanutti/kubebox) - Terminal console for Kubernetes


### PR DESCRIPTION
I added this under the monitoring section, as  I don't think it should be grouped with network plugins. The best place for it is probably a logging section though