### PR TITLE
Add Virtual Kubelet

### DIFF
--- a/README.md
+++ b/README.md
@@ -495,6 +495,7 @@ Projects
 * [OpenFaaS](https://github.com/alexellis/faas)
 * [FaaS-netes](https://github.com/alexellis/faas-netes)
 * [Nuclio](https://github.com/nuclio/nuclio)
+* [Virtual Kubelet](https://github.com/virtual-kubelet/virtual-kubelet) - Allows nodes to be backed by other services and providers.
 
 ## Operators
 


### PR DESCRIPTION
* Announced at the Azure/Docker/Kubernetes meetup in Seattle today.

Virtual Kubelet is an open source Kubernetes kubelet implementation that masquerades as a kubelet for the purposes of connecting Kubernetes to other APIs. This allows the nodes to be backed by other services like ACI, Hyper.sh, AWS, Azure, etc. This connector features a pluggable architecture and direct use of Kubernetes primitives, making it much easier to build on.