### PR TITLE
Removing KPM

### DIFF
--- a/README.md
+++ b/README.md
@@ -431,7 +431,6 @@ Projects
 ## Package Managers
 
 * [Helm](http://helm.sh)
-* [KPM](https://github.com/coreos/kpm)
 
 ## Monitoring Services
 


### PR DESCRIPTION
KPM Package manager is deprecated and it is no longer developed. It is made official by CoreOS last year and they have not made any changes for last one year