### PR TITLE
Removing kube-ui

### DIFF
--- a/README.md
+++ b/README.md
@@ -440,7 +440,6 @@ Projects
 * [Console](https://github.com/kubernetes/dashboard)
 * [Datadog](http://www.datadoghq.com/)
 * [Heapster](https://github.com/kubernetes/heapster)
-* [Kube-ui](https://github.com/kubernetes/kube-ui)
 * [Kubebox](https://github.com/astefanutti/kubebox) - Terminal console for Kubernetes
 * [Kubedash](https://github.com/kubernetes/kubedash)
 * [Kubernetes Operational View](https://github.com/hjacobs/kube-ops-view) - read-only system dashboard for multiple K8s clusters


### PR DESCRIPTION
kube-ui has been deprecated and not being developed for past 2 years.