### PR TITLE
Add Gitkube

### DIFF
--- a/README.md
+++ b/README.md
@@ -473,7 +473,7 @@ Projects
    * [On-demand Jenkins slaves with Kubernetes and the Google Container Engine](http://www.cloudbees.com/blog/demand-jenkins-slaves-kubernetes-and-google-container-engine)
    * [Jenkins setups for Kubernetes and Docker Workflow](http://iocanel.blogspot.in/2015/09/jenkins-setups-for-kubernetes-and.html)
    * [Lab: Build a Continuous Deployment Pipeline with Jenkins and Kubernetes](https://github.com/GoogleCloudPlatform/continuous-deployment-on-kubernetes)
-* [Jenkins X](http://jenkins-x.io/) - CI/CD for Kubernetes using Jenkins   
+* [Jenkins X](http://jenkins-x.io/) - CI/CD for Kubernetes using Jenkins
 * [kb8or](https://github.com/UKHomeOffice/kb8or)
 * [Wercker](http://blog.wercker.com/topic/kubernetes)
 * [Shippable](http://blog.shippable.com/topic/kubernetes)
@@ -639,6 +639,7 @@ Projects
 * [Psykube](https://github.com/commercialtribe/psykube)
 * [Brigade](https://github.com/Azure/brigade) - Event Based Scripting using JavaScript
 * [Skaffold](https://github.com/GoogleCloudPlatform/skaffold) - Command line tool that facilitates continuous development for Kubernetes applications.
+* [Gitkube](https://gitkube.sh/) - Build and deploy docker images on Kubernetes using `git push`.
 
 ## Configuration
 


### PR DESCRIPTION
Gitkube is a tool for building and deploying docker images on Kubernetes using git push.
After a simple initial setup, developers can simply keep git push-ing their repos to build and deploy to Kubernetes automatically.
Ideal for development where you can push your WIP branch to the cluster to test.

977+ stars: Github: https://github.com/hasura/gitkube