### PR TITLE
Add GCP Skaffold CLI Tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -634,6 +634,7 @@ Projects
 * [Deployment manager](https://cloud.google.com/deployment-manager/)
 * [Psykube](https://github.com/commercialtribe/psykube)
 * [Brigade](https://github.com/Azure/brigade) - Event Based Scripting using JavaScript
+* [Skaffold](https://github.com/GoogleCloudPlatform/skaffold) - Command line tool that facilitates continuous development for Kubernetes applications.
 
 ## Configuration
 


### PR DESCRIPTION
Skaffold is a command line tool that facilitates continuous development for Kubernetes applications. You can iterate on your application source code locally then deploy to local or remote Kubernetes clusters. Skaffold handles the workflow for building, pushing and deploying your application. It can also be used in an automated context such as a CI/CD pipeline to leverage the same workflow and tooling when moving applications to production.

Stars: 1800+, Google Cloud Platform tool