### PR TITLE
Add entry for kubectl-plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -625,6 +625,7 @@ Projects
 * [Vikube](https://github.com/c9s/vikube.vim) - Kubernetes operations from Vim, in Vim
 * [kube-ps1](https://github.com/jonmosco/kube-ps1) - Kubernetes prompt helper for bash and zsh.
 * [kubensx](https://github.com/shyiko/kubensx) - Simpler Cluster/User/Namespace switching for Kubernetes (featuring interactive mode and wildcard/fuzzy matching).
+* [kubectl-plugins](https://github.com/jordanwilson230/kubectl-plugins) - A collection of kubectl plugins handling everything from easy context switches to exec'ing into a container as any user (root included). Slightly tailored towards GKE users.
 
 ## Application deployment orchestration
 


### PR DESCRIPTION
Add an entry for kubectl-plugins, under the 'API/CLI adaptors' section.  The plugins are simple and address some of the limitations of kubernetes such as https://github.com/kubernetes/kubernetes/issues/30656 (using kubectl exec with a user flag).  This was a significant pain to deal with while trying to maintain proper security contexts amongst my k8 containers.

The homepage has animated gifs in the README for quick demos on some plugins.

Note that the number of stars was reset after recently transferring ownership of the repository 😭 