### PR TITLE
Add dex

### DIFF
--- a/README.md
+++ b/README.md
@@ -662,6 +662,7 @@ Projects
 
 ## Security
 
+* [Dex](https://github.com/coreos/dex) - OpenID and OAuth for Kubernetes
 * [Trireme](http://github.com/aporeto-inc/trireme-kubernetes)
 * [Aquasec](http://blog.aquasec.com/topic/kubernetes)
 * [Twistlock](http://www.twistlock.com/)


### PR DESCRIPTION
Not sure if we should add an Authentication category?


Dex's main production use is as an auth-N addon in CoreOS's enterprise Kubernetes solution, Tectonic. Dex runs natively on top of any Kubernetes cluster using Third Party Resources and can drive API server authentication through the OpenID Connect plugin. Clients, such as the Tectonic Console and kubectl, can act on behalf users who can login to the cluster through any identity provider dex supports.