### PR TITLE
Add Click

### DIFF
--- a/README.md
+++ b/README.md
@@ -615,6 +615,7 @@ Projects
 
 ## API/CLI adaptors
 
+* [click](https://github.com/databricks/click) - A CLI focused REPL for quickly interacting with Kubernetes objects.
 * [kube-prompt](https://github.com/c-bata/kube-prompt) - Interactive kubernetes client built using go-prompt.
 * [Kube-shell](https://github.com/cloudnativelabs/kube-shell) - Integrated shell for working with the Kubernetes CLI
 * [Kubebot](https://github.com/harbur/kubebot)


### PR DESCRIPTION
This adds Click to the CLI section.  I added at the top as the list looked (mostly) alphabetized, but if the convention is to add at the bottom, let me know and I'll move it down.

Thanks!