### PR TITLE
Add kubectl-tmux-logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -641,6 +641,7 @@ Projects
 * [Vikube](https://github.com/c9s/vikube.vim) - Kubernetes operations from Vim, in Vim
 * [kube-ps1](https://github.com/jonmosco/kube-ps1) - Kubernetes prompt helper for bash and zsh.
 * [kube-tmux](https://github.com/jonmosco/kube-tmux) - Kubernetes tmux plugin to display the current context and namespace
+* [kubectl-tmux-logs](https://github.com/normanjoyner/kubectl-tmux-logs) - A kubectl plugin to display container logs within separate tmux panes
 * [kubensx](https://github.com/shyiko/kubensx) - Simpler Cluster/User/Namespace switching for Kubernetes (featuring interactive mode and wildcard/fuzzy matching).
 * [stern](https://github.com/wercker/stern) - Multi pod and container log tailing
 * [kubeplay](https://github.com/errordeveloper/kubeplay)


### PR DESCRIPTION
[kubectl-tmux-logs](https://github.com/normanjoyner/kubectl-tmux-logs) is a simple but useful kubectl plugin for displaying container logs in separate tmux panes