### PR TITLE
Add a link to the Awesome Helm list

### DIFF
--- a/README.md
+++ b/README.md
@@ -424,6 +424,7 @@ Projects
 ## Package Managers
 
 * [Helm](http://helm.sh)
+* [Awesome Helm](https://github.com/cdwv/awesome-helm) - a list of awesome Helm resources
 
 ## Monitoring Services
 


### PR DESCRIPTION
Hello, please consider linking the Awesome Helm list - https://github.com/cdwv/awesome-helm that we're maintaining as a resource of Helm-specific links (documentation, charts, etc.)