### PR TITLE
Add a link to the Awesome Helm list

### DIFF
--- a/README.md
+++ b/README.md
@@ -424,6 +424,7 @@ Projects
 ## Package Managers
 
 * [Helm](http://helm.sh)
+* [Awesome Helm](https://github.com/cdwv/awesome-helm) - a list of awesome Helm resources
 
 ## Monitoring Services
 

--- a/README.md
+++ b/README.md
@@ -423,8 +423,7 @@ Projects
 
 ## Package Managers
 
-* [Helm](http://helm.sh)
-* [Awesome Helm](https://github.com/cdwv/awesome-helm) - a list of awesome Helm resources
+* [Helm](http://helm.sh) - For further information, please check out - [Awesome Helm](https://github.com/cdwv/awesome-helm).
 
 ## Monitoring Services
 


### PR DESCRIPTION
I'm opening a new PR since #255 was closed because we didn't meet the criteria at that time.

Hello, please reconsider linking the Awesome Helm list - https://github.com/cdwv/awesome-helm that we're maintaining as a resource of Helm-specific links (documentation, charts, etc.)
