### PR TITLE
added ICP - IBM Cloud Private to Enterprise Kubernetes Products

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,6 +308,7 @@ Managed Kubernetes
    - [Vsphere](http://www.vmware.com/products/vsphere.html) - VMWare VSphere
    - [Rackspace](https://www.rackspace.com/en-in) - Rackspace
    - [Alibaba Cloud](https://www.alibabacloud.com/product/kubernetes) - Alibaba Cloud Container Service for Kubernetes
+	 - [IKS](https://www.ibm.com/cloud/container-service) - IBM Cloud Kubernetes Service
 
   ### [Paas](#paas)
 

--- a/README.md
+++ b/README.md
@@ -320,7 +320,6 @@ Managed Kubernetes
   - [Rancher](http://rancher.com/running-kubernetes-aws-rancher/)
   - [OpenShift Origin](http://www.openshift.org/)
   - [Eldarion Cloud](http://eldarion.cloud)
-  - [IBM Bluemix Container Service](http://www.ibm.com/cloud-computing/bluemix/containers)
   - [Hasura](http://www.hasura.io)
   - [teresa](https://github.com/luizalabs/teresa) - Simple PAAS that runs on top of Kubernetes.
 

--- a/README.md
+++ b/README.md
@@ -299,6 +299,7 @@ Managed Kubernetes
   - [SUSE Container as a Service](http://www.suse.com/betaprogram/caasp-beta/)
   - [Kubermatic](http://www.loodse.com/)
   - [Canonical Distribution of Kubernetes - CDK](https://www.ubuntu.com/kubernetes)
+	- [IBM Cloud Private](https://www.ibm.com/cloud/private)
 
   ### [Public/Private Cloud](#publicprivate-cloud)
 


### PR DESCRIPTION
Removed IBM Bluemix Container Service and added IBM Cloud Kubernetes Service. Also added IBM Cloud Private.