### PR TITLE
Add release notes for K8s 1.11

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,7 @@ Release Notes
 
 *Official release notes from the Kubernetes team on Stable Kubernetes Releases*
 
+* [Kubernetes-1.11](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG-1.11.md)
 * [Kubernetes-1.10](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG-1.10.md)
 * [Kubernetes-1.9](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG-1.9.md)
 * [Kubernetes-1.8](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG-1.8.md)


### PR DESCRIPTION
Kubernetes 1.11 was [just](https://kubernetes.io/blog/2018/06/27/kubernetes-1.11-release-announcement/) released.