### PR TITLE
Updated README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,7 +313,7 @@ Managed Kubernetes
 
    - [GKE](https://cloud.google.com/container-engine/) - Google Kubernetes Engine
    - [AWS EKS](https://aws.amazon.com/eks/) - Amazon Elastic Container Service
-   - [Azure AKS](https://docs.microsoft.com/en-us/azure/aks/) - Azure Container Service
+   - [Azure AKS](https://docs.microsoft.com/en-us/azure/aks/) - Azure Kubernetes Service
    - [Vsphere](http://www.vmware.com/products/vsphere.html) - VMWare VSphere
    - [Rackspace](https://www.rackspace.com/en-in) - Rackspace
    - [Alibaba Cloud](https://www.alibabacloud.com/product/kubernetes) - Alibaba Cloud Container Service for Kubernetes


### PR DESCRIPTION
Changed Azure Container Services to Azure Kubernetes Services as Azure Container Services is being deprecated.