### PR TITLE
kubefwd

### DIFF
--- a/README.md
+++ b/README.md
@@ -634,6 +634,7 @@ Projects
 * [Kubebot](https://github.com/harbur/kubebot)
 * [kubectx](https://github.com/ahmetb/kubectx) - switch between clusters on kubectl
 * [kubens](https://github.com/ahmetb/kubectx) - switch between namespaces on kubectl
+* [kubefwd](https://github.com/txn2/kubefwd) - Kube Forward is a command line utility built to port forward some or all pods within a Kubernetes namespace.
 * [StackStorm](https://github.com/StackStorm/st2)
 * [Kubefuse](http://opencredo.com/introducing-kubefuse-file-system-kubernetes/)
 * [Ksql](https://github.com/brendandburns/ksql)


### PR DESCRIPTION
added kubefwd to API/CLI adaptors. Kube Forward is a command line utility built to port forward some or all pods within a Kubernetes namespace. https://github.com/txn2/kubefwd