### PR TITLE
Add kubectl-plugins to list

### DIFF
--- a/README.md
+++ b/README.md
@@ -688,6 +688,7 @@ Projects
 * [kubensx](https://github.com/shyiko/kubensx) - Simpler Cluster/User/Namespace switching for Kubernetes (featuring interactive mode and wildcard/fuzzy matching).
 * [stern](https://github.com/wercker/stern) - Multi pod and container log tailing
 * [kubeplay](https://github.com/errordeveloper/kubeplay)
+* [kubectl-plugins](https://github.com/jordanwilson230/kubectl-plugins) - A collection of kubectl plugins handling everything from easy context switches to exec'ing into a container as any user (root included). Slightly tailored towards GKE users.
 
 ## Application deployment orchestration
 

--- a/README.md
+++ b/README.md
@@ -688,7 +688,7 @@ Projects
 * [kubensx](https://github.com/shyiko/kubensx) - Simpler Cluster/User/Namespace switching for Kubernetes (featuring interactive mode and wildcard/fuzzy matching).
 * [stern](https://github.com/wercker/stern) - Multi pod and container log tailing
 * [kubeplay](https://github.com/errordeveloper/kubeplay)
-* [kubectl-plugins](https://github.com/jordanwilson230/kubectl-plugins) - A collection of kubectl plugins handling everything from easy context switches to exec'ing into a container as any user (root included). Slightly tailored towards GKE users.
+* [kubectl-plugins](https://github.com/jordanwilson230/kubectl-plugins) - A collection of kubectl plugins handling everything from easy context switches to connecting to a container as any user (root included) via exec. Slightly tailored towards GKE users.
 
 ## Application deployment orchestration
 


### PR DESCRIPTION
Hi, just wanted to resubmit a PR I opened shortly after the criteria guideline was put into place.

Previous PR: #214

Summary:

Adds an entry for kubectl-plugins, under the 'API/CLI adaptors' section. The plugins are simple and address some of the limitations of kubernetes such as kubernetes/kubernetes#30656 (using kubectl exec with a user flag). This was a significant pain to deal with while trying to maintain proper security contexts amongst my k8 containers.

The homepage has animated gifs in the README for quick demos on some plugins.