### PR TITLE
Move Kubeapps under Web applications

### DIFF
--- a/README.md
+++ b/README.md
@@ -546,7 +546,6 @@ Projects
 
 * [Funktion](https://github.com/fabric8io/funktion)
 * [Fission](https://github.com/platform9/fission)
-* [Kubeapps](https://github.com/kubeapps/kubeapps) - set of tools (application dashboard, Serverless framework, and Secret generator) to build FaaS apps on top of Kubernetes
 * [Kubeless](https://github.com/skippbox/kubeless)
 * [OpenWhisk](https://github.com/openwhisk)
 * [Iron.io](http://iron.io)
@@ -668,6 +667,7 @@ Projects
 ## Web applications
 
 * [Kubernator](https://github.com/smpio/kubernator)
+* [Kubeapps](https://github.com/kubeapps/kubeapps) - A web-based UI for deploying and managing applications in Kubernetes clusters
 
 ## Desktop applications
 


### PR DESCRIPTION
Great to see Kubeapps on this list :), thanks for adding it @alljames! There was some initial confusion (https://github.com/ramitsurana/awesome-kubernetes/pull/246) on where to place it - now that our project goals are to focus on application deployment and management, I think the Web applications category might be a better home.