### PR TITLE
Add Eclipse Che and OpenShift.io to DevPlatform

### DIFF
--- a/README.md
+++ b/README.md
@@ -329,7 +329,9 @@ Managed Kubernetes
 
   ### [Developer Platform](#developer-platform)
 
-  - [Fabric8](http://fabric8.io)
+  - [Fabric8](http://fabric8.io) - integrated development platform with CD features
+  - [Eclipse Che] (https://github.com/eclipse/che) - cloud development workspaces with SSH and multi-user support
+  - [OpenShift.io](https://openshift.io) - hosted Fabric8 with Che and Jenkins CI integration
   - [Spring Cloud integration](https://github.com/fabric8io/spring-cloud-kubernetes)
   - [Mantl](https://github.com/mantl/mantl)
   - [goPaddle](http://www.gopaddle.io)

--- a/README.md
+++ b/README.md
@@ -330,7 +330,7 @@ Managed Kubernetes
   ### [Developer Platform](#developer-platform)
 
   - [Fabric8](http://fabric8.io) - integrated development platform with CD features
-  - [Eclipse Che] (https://github.com/eclipse/che) - cloud development workspaces with SSH and multi-user support
+  - [Eclipse Che](https://github.com/eclipse/che) - cloud development workspaces with SSH and multi-user support
   - [OpenShift.io](https://openshift.io) - hosted Fabric8 with Che and Jenkins CI integration
   - [Spring Cloud integration](https://github.com/fabric8io/spring-cloud-kubernetes)
   - [Mantl](https://github.com/mantl/mantl)


### PR DESCRIPTION
Adds the following services to the Development Platform Section:

- Eclipse Che from Eclipse Foundation/ Red Hat Inc.

- OpenShift.io from Red Hat Inc. - Presumably a Fabric8 hosted solution with Jenkins CI and Eclipse Che tooling. Probably the Fabric8 hosted reference implementation.