### PR TITLE
Add 'kube-fledged' to 'Related Software' section

### DIFF
--- a/README.md
+++ b/README.md
@@ -461,6 +461,7 @@ Projects
 * [Hypernetes](https://github.com/hyperhq/hypernetes)
 * [Kubernetes Cluster Federation (previously Ubernetes)](https://kubernetes.io/docs/concepts/cluster-administration/federation/)
 * [kmachine](https://github.com/skippbox/kmachine)
+* [kube-fledged](https://github.com/senthilrch/kube-fledged) - A K8S add-on for creating and managing a cache of container images directly on cluster worker nodes
 * [Kubefuse](http://opencredo.com/introducing-kubefuse-file-system-kubernetes/)
 * [Kubefwd](https://github.com/txn2/kubefwd) - Bulk port forwarding Kubernetes services for local development.
 * [KubeSpray](https://github.com/kubespray)


### PR DESCRIPTION
**_kube-fledged_** is a kubernetes add-on for creating and managing a cache of container images directly on the worker nodes of a kubernetes cluster. It allows a user to define a list of images and onto which worker nodes those images should be cached (i.e. pre-pulled). As a result, application pods start almost instantly, since the images need not be pulled from the registry.

_kube-fledged_ provides CRUD APIs to manage the lifecycle of the image cache, and supports several configurable parameters to customize the functioning as per one's needs.

URL:- https://github.com/senthilrch/kube-fledged

**Note:-** _kube-fledged_ fulfills the [Acceptance Criteria](https://github.com/ramitsurana/awesome-kubernetes/blob/master/guidelines/CRITERIA_OF_SUBMISSION.md)