### PR TITLE
Add Argo CD to Continuous Delivery section

### DIFF
--- a/README.md
+++ b/README.md
@@ -587,7 +587,6 @@ Projects
 * [Codefresh](https://codefresh.io/) - Kubernetes CI/CD platform (with private Docker and Helm Chart repositories)
 * [k8s-deploy-helper](https://github.com/lifechurch/k8s-deploy-helper) - Framework to easily deploy Kubernetes applications via GitLab.
 * [Argo CD](https://github.com/argoproj/argo-cd) - Declarative continuous deployment for Kubernetes. 
-* [Argo CI](https://github.com/argoproj/argo-ci) - Continuous integration and delivery for Kubernetes powered by Argo workflows.
 
 ## Serverless Implementations
 

--- a/README.md
+++ b/README.md
@@ -586,6 +586,8 @@ Projects
 * [Weave Flux – GitOps reconcoliation operator](https://github.com/weaveworks/flux)
 * [Codefresh](https://codefresh.io/) - Kubernetes CI/CD platform (with private Docker and Helm Chart repositories)
 * [k8s-deploy-helper](https://github.com/lifechurch/k8s-deploy-helper) - Framework to easily deploy Kubernetes applications via GitLab.
+* [Argo CD](https://github.com/argoproj/argo-cd) - Declarative continuous deployment for Kubernetes. 
+* [Argo CI](https://github.com/argoproj/argo-ci) - Continuous integration and delivery for Kubernetes powered by Argo workflows.
 
 ## Serverless Implementations
 


### PR DESCRIPTION
I realize that Argo Workflow Engine is already mentioned in the "Related Software" section but I believe the Argo CD project deserves a dedicated mention in the "Continuous Delivery" section.
