### PR TITLE
Add link to authentication article

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,6 +267,7 @@ Useful Articles
 
 - [Kubernetes Authentication plugins and kubeconfig](http://www.dasblinkenlichten.com/kubernetes-authentication-plugins-and-kubeconfig/) by [Jon Langemak](https://twitter.com/blinken_lichten)
 - [Kubernetes Authentication - OpenID Connect](http://www.devoperandi.com/kubernetes-authentication-openid-connect/) by [Michael Ward](https://twitter.com/DevoperandI)
+- [Kubernetes authentication via GitHub OAuth and Dex](https://medium.com/preply-engineering/k8s-auth-a81f59d4dff6) by [Amet Umerov](https://github.com/Amet13)
 
 ### [Networking](#networking)
 


### PR DESCRIPTION
This is an article about Kubernetes authentication via GitHub OAuth and Dex.
I think it could be useful here.