### PR TITLE
pykube -> pykube-ng

### DIFF
--- a/README.md
+++ b/README.md
@@ -493,7 +493,7 @@ Developer Libraries/ Scripts
 
   ### [Python](#python)
 
-   - [Pykube](https://github.com/kelproject/pykube)
+   - [Pykube](https://github.com/hjacobs/pykube)
 
   ### [Jenkins](#jenkins)
 


### PR DESCRIPTION
The [original pykube](https://github.com/kelproject/pykube/) is unmaintained (git repo is archived) and I'm trying to resurrect and maintain it (already released on PyPI). 

The [new repo](https://github.com/hjacobs/pykube) does not have any stars yet, but I consider this PR an improvement as the current link points to an unmaintained project (from the README: "If you see a package or project here that is no longer maintained or is not a good fit, please submit a pull request to improve this file.").