### PR TITLE
Remove Fabric8 and Openshift.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -343,9 +343,7 @@ Managed Kubernetes
 
   ### [Developer Platform](#developer-platform)
 
-  - [Fabric8](http://fabric8.io) - integrated development platform with CD features
   - [Eclipse Che](https://github.com/eclipse/che) - cloud development workspaces with SSH and multi-user support
-  - [OpenShift.io](https://openshift.io) - hosted Fabric8 with Che and Jenkins CI integration
   - [Spring Cloud integration](https://github.com/fabric8io/spring-cloud-kubernetes)
   - [Mantl](https://github.com/mantl/mantl)
   - [goPaddle](http://www.gopaddle.io)


### PR DESCRIPTION
Fabric8 upstream project is abandoned and redhat's fork of it called openshift.io is not ready for public consumption yet as it's still a private beta. Both do not add any value to this otherwise pretty great list of resources.  

Source: I used to work on these projects at Redhat.