### PR TITLE
Add OperatorHub.io as a central Kubernetes Operator market place

### DIFF
--- a/README.md
+++ b/README.md
@@ -616,6 +616,7 @@ Projects
 
 ## Operators
 
+* [OperatorHub.io](https://www.operatorhub.io)
 * [Prometheus](https://github.com/coreos/prometheus-operator)
 * [Kong API](https://github.com/upmc-enterprises/kong-operator)
 * [Kubernetes Operators](https://github.com/sapcc/kubernetes-operators)


### PR DESCRIPTION
OperatorHub.io was launched by Red Hat in conjunction with Amazon, Microsoft, and Google.

#### Exceptions

  - Project is hosted by a recognized organization
