### PR TITLE
Update kubecfg location (ksonnet -> bitnami)

### DIFF
--- a/README.md
+++ b/README.md
@@ -811,7 +811,7 @@ Projects
 * [kubegen](https://github.com/errordeveloper/kubegen)
 * [kustomize](https://github.com/kubernetes-sigs/kustomize) - Customization using partial specs
 * [kapitan](https://github.com/deepmind/kapitan) - Manage complex deployments using jsonnet and jinja2
-* [kubecfg](https://github.com/ksonnet/kubecfg) - Combines jsonnet and kubectl to let you declare systems in an easy to override way
+* [kubecfg](https://github.com/bitnami/kubecfg) - Combines jsonnet and kubectl to let you declare systems in an easy to override way
 * [Pulumi](https://www.pulumi.com/kubernetes/) - Provides a SDK for k8s deployments targeting on-premises clusters and major cloud vendors' managed services.
 
 ## Security


### PR DESCRIPTION
We recently moved the `kubecfg` component to the `bitnami` organization (due to a reorganization in the `ksonnet` org).

GitHub does the redirect automatically so all existing links work but nevertheless I think it would be better to have the new official link here.

Context/Proof: https://github.com/ksonnet/kubecfg/issues/247#issuecomment-479976130

Thank You for creating a Pull Request. We appreciate your efforts towards contributing the awesome-kubernetes list.

As a part of our practice, we would like to select the projects based on the below criteria. Please ensure that your submission is fulfilling the below requirements. Thanks

#### Requirements for any project submissions


  - Minimum of 25 GitHub Stars
  - Minimum of 5+ contributors
  - Proper documentation of the project and its goals

#### Exceptions

  - Project is hosted by a recognized organization
