### PR TITLE
Added Cloudsmith (Kubernetes Registry)

### DIFF
--- a/README.md
+++ b/README.md
@@ -545,7 +545,7 @@ Projects
 ## Package Managers
 
 * [Helm](http://helm.sh) - For further information, please check out - [Awesome Helm](https://github.com/cdwv/awesome-helm).
-* [Cloudsmith](https://cloudsmith.io/l/helm-repository/) - A fully managed package management SaaS, with first-class support for public and private Kubernetes registries (Docker + Helm Charts, plus many others). Has a generous free-tier and is also completely free for open-source.
+* [Cloudsmith](https://cloudsmith.io/l/helm-repository/) - A fully managed package management SaaS, with first-class support for public and private Kubernetes registries (Docker + Helm Charts, plus many others).
 
 ## Monitoring Services
 

--- a/README.md
+++ b/README.md
@@ -545,6 +545,7 @@ Projects
 ## Package Managers
 
 * [Helm](http://helm.sh) - For further information, please check out - [Awesome Helm](https://github.com/cdwv/awesome-helm).
+* [Cloudsmith](https://cloudsmith.io/l/helm-repository/) - A fully managed package management SaaS, with first-class support for public and private Kubernetes registries (Docker + Helm Charts, plus many others). Has a generous free-tier and is also completely free for open-source.
 
 ## Monitoring Services
 


### PR DESCRIPTION
Hi! This PR adds a link to [Cloudsmith](https://cloudsmith.io), which is a package management service SaaS. It's commercial, but it is completely free for open-source and it has generous free tiers otherwise. It has first-class support for Kubernetes / Docker + Helm (and many other package formats, such as Npm), plus org/teams management, granular access controls, private repositories, repository-specific entitlements, a worldwide content distribution network, webhooks, access logs, etc. Thank you. :-)

Full disclosure: I work at Cloudsmith. \o/

Thank You for creating a Pull Request. We appreciate your efforts towards contributing the awesome-kubernetes list.

As a part of our practice, we would like to select the projects based on the below criteria. Please ensure that your submission is fulfilling the below requirements. Thanks

#### Requirements for any project submissions


  - Minimum of 25 GitHub Stars
  - Minimum of 5+ contributors
  - Proper documentation of the project and its goals

#### Exceptions

  - Project is hosted by a recognized organization
