### PR TITLE
Adds chaoskube

### DIFF
--- a/README.md
+++ b/README.md
@@ -597,6 +597,7 @@ Projects
 
 *Test your applications running on Kubernetes*
 
+* [chaoskube](https://github.com/linki/chaoskube) - periodically kills random pods in your Kubernetes cluster
 * [k8s-testsuite](https://github.com/mrahbar/k8s-testsuite) - Helm chart for network and loadtesting of a Kubernetes cluster
 * [kboom](https://github.com/mhausenblas/kboom) - The Kubernetes scale & soak load tester
 * [kind](https://github.com/bsycorp/kind) - A single node cluster to run your CI tests against thats ready in 30 seconds


### PR DESCRIPTION
Adds [chaoskube](https://github.com/linki/chaoskube) to the tooling section alongside similar projects like `kube-monkey`. `chaoskube` is a simple tool that periodically kills random pods in a cluster. It allows to filter pods by various means such as labels, annotations, pod name, and livetime of the pod.

Added in alphabetical order. Hope that's ok.

- [x] Minimum of 25 GitHub Stars
- [x] Minimum of 3+ contributors
- [x] Proper documentation of the project and its goals