### PR TITLE
Rename StackPoint Cloud to NKS

### DIFF
--- a/README.md
+++ b/README.md
@@ -348,7 +348,7 @@ Managed Kubernetes
   - [Platform9](http://platform9.com)
   - [OpenShift Online](http://www.openshift.com/devpreview/index.html)
   - [Eldarion Cloud](http://eldarion.cloud/)
-  - [NetApp Kubernetes Service (formerly StackPoint Cloud)](https://nks.netapp.io/)
+  - [NetApp Kubernetes Service (formerly StackPoint Cloud)](https://cloud.netapp.com/kubernetes-service)
   - [Hasura](https://hasura.io/)
   - [ELASTX](https://www.elastx.se/)
 

--- a/README.md
+++ b/README.md
@@ -348,7 +348,7 @@ Managed Kubernetes
   - [Platform9](http://platform9.com)
   - [OpenShift Online](http://www.openshift.com/devpreview/index.html)
   - [Eldarion Cloud](http://eldarion.cloud/)
-  - [StackPoint Cloud](http://stackpoint.io/)
+  - [NetApp Kubernetes Service (formerly StackPoint Cloud)](https://nks.netapp.io/)
   - [Hasura](https://hasura.io/)
   - [ELASTX](https://www.elastx.se/)
 


### PR DESCRIPTION
StackPoint Cloud is now NetApp Kubernetes Service (NKS)

It would be better if Managed Kubernetes providers were ordered alphabetically, but I did not change that. I hope a maintainer can edit this PR and make that modification

