### PR TITLE
Add Okteto link

### DIFF
--- a/README.md
+++ b/README.md
@@ -373,6 +373,7 @@ Managed Kubernetes
   - [Garden](https://garden.io) - Orchestrates your development workflows to make developing microservices faster and easier.
   - [goPaddle](http://www.gopaddle.io)
   - [Knative](https://github.com/knative/) - Platform to build, deploy, and manage modern serverless workloads
+  - [Okteto](https://github.com/okteto/okteto) - Develop directly in any Kubernetes cluster. No commit, build or push required.
   - [Mantl](https://github.com/mantl/mantl)
   - [Spring Cloud integration](https://github.com/fabric8io/spring-cloud-kubernetes)
   - [VAMP](http://vamp.io)


### PR DESCRIPTION
5  contributors. 288 starts. Okteto lets you develop directly in any Kubernetes cluster. No commit, build or push required.