### PR TITLE
Kubernetes Resource Report

### DIFF
--- a/README.md
+++ b/README.md
@@ -787,6 +787,7 @@ Projects
 ## Web applications
 
 * [Kubernator](https://github.com/smpio/kubernator)
+* [Kubernetes Resource Report](https://github.com/hjacobs/kube-resource-report) - report Kubernetes cluster and pod resource requests vs usage and generate static HTML
 * [Kubeapps](https://github.com/kubeapps/kubeapps) - A web-based UI for deploying and managing applications in Kubernetes clusters
 * [Polaris](https://github.com/reactiveops/polaris) - An open source dashboard for Kubernetes best practices
 


### PR DESCRIPTION
Add Kubernetes Resource Report which can generate a HTML report of CPU/memory requests vs. usage (collected via Metrics API/Heapster) for one or more Kubernetes clusters.

Live demo is available on https://demo.j-serv.de/

Criteria is matched:

* project has 292 GitHub stars
* project has 15 contributors