### PR TITLE
Add zarvis.ai to Paas platform list

### DIFF
--- a/README.md
+++ b/README.md
@@ -418,6 +418,7 @@ Managed Kubernetes
   - [Rancher](http://rancher.com/running-kubernetes-aws-rancher/)
   - [teresa](https://github.com/luizalabs/teresa) - Simple PAAS that runs on top of Kubernetes.
   - [WSO2](http://wso2.com)
+  - [Z.A.R.V.I.S.](https://zarvis.ai) - Deploy Github projects to managed Kubernetes for free
 
 Interactive Learning Environments
 =======================================================================


### PR DESCRIPTION
Z.A.R.V.I.S. is a Paas platform that deploys Github projects on managed Kubernetes with free tier option with optional extra quota for open source project.