### PR TITLE
Kubernetes Web View

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,6 +266,7 @@ Useful Articles
 - [Kubernetes Monitoring Guide](http://www.datadoghq.com/blog/monitoring-kubernetes-era/) by [JM Saponaro](http://github.com/JayJayM)
 - [Installing cAdvisor and Heapster on bare metal Kubernetes](http://www.dasblinkenlichten.com/installing-cadvisor-and-heapster-on-bare-metal-kubernetes/) by [Jon Langemak](https://twitter.com/blinken_lichten)
 - [How to Monitor Kubernetes: A 4-Part Series](http://sysdig.com/blog/monitoring-kubernetes-with-sysdig-cloud/)
+- [Kubernetes Web UIs in 2019](https://srcco.de/posts/kubernetes-web-uis-in-2019.html)
 
 ### [Security](#security)
 

--- a/README.md
+++ b/README.md
@@ -589,6 +589,7 @@ Projects
 * [Kubebox](https://github.com/astefanutti/kubebox) - Terminal console for Kubernetes
 * [Kubedash](https://github.com/kubernetes/kubedash) - **Deprecated** repository is archived and read-only
 * [Kubernetes Operational View](https://github.com/hjacobs/kube-ops-view) - read-only system dashboard for multiple K8s clusters
+* [Kubernetes Web View](https://codeberg.org/hjacobs/kube-web-view) - list and view all Kubernetes resources (incl. CRDs) with permalink-friendly URLs in a plain-HTML frontend
 * [Kubespy](https://github.com/pulumi/kubespy) - Tools for observing Kubernetes resources in real time, powered by Pulumi.
 * [Kubetail](https://github.com/johanhaleby/kubetail)
 * [Kubewatch](https://github.com/skippbox/kubewatch)


### PR DESCRIPTION
Link new project Kubernetes Web View:

> Kubernetes Web View allows to list and view all Kubernetes resources (incl. CRDs) with permalink-friendly URLs in a plain-HTML frontend. This tool was mainly developed to provide a web-version of kubectl for troubleshooting and supporting colleagues.

See introductory blog post on https://srcco.de/posts/kubernetes-web-uis-in-2019.html

### Rrequirements
- Minimum of 25 GitHub Stars: yes, mirror on https://github.com/hjacobs/kube-web-view has 32 stars plus 9 stars on https://codeberg.org/hjacobs/kube-web-view
- Minimum of 3+ contributors: no, only two contributors so far
- Proper documentation of the project and its goals: yes, see https://kube-web-view.readthedocs.io/en/latest/ and https://srcco.de/posts/kubernetes-web-uis-in-2019.html
