### PR TITLE
Add Hyperctl

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,7 @@ Installers
 * [Conjure-up](https://github.com/conjure-up/conjure-up) - Ubuntu - Cloud Agnostique
 * [Docker for MAC](https://store.docker.com/editions/community/docker-ce-desktop-mac) - Run Kubernetes and Docker locally on your MAC (Edge Channel)
 * [Docker for Windows](https://store.docker.com/editions/community/docker-ce-desktop-windows) - Run Kubernetes and Docker locally on your Windows PC (Edge Channel)
+* [Hyperctl](https://github.com/youurayy/hyperctl) - Multi-node Kubernetes with CentOS/Ubuntu in Hyperkit (Mac) or Hyper-V (Windows)
 * [Juju](https://jujucharms.com/canonical-kubernetes) - Ubuntu - Cloud Agnostique
 * [k3s](https://github.com/rancher/k3s) - Lightweight Kubernetes. Easy to install, half the memory, all in a binary less than 40mb
 * [kind](https://kind.sigs.k8s.io) -  A tool for running local Kubernetes clusters using Docker container “nodes”


### PR DESCRIPTION
Hyperctl is a script for setup and control of locally-hosted multi-node (multi-VM) Kubernetes cluster.

Both Mac (Hyperkit) and Windows (Hyper-V) are supported (and tested).

I'm submitting this despite it's not meeting the criteria of number of stars and maintainers (feel free to close), because I think it fills a gap between Minikube (single node, complexity, many issues) and a real cloud-hosted multi-node Kubernetes.

In addition, the script (optionally) allows using Docker locally without actually installing Docker for Desktop (again, keeping you close to the internals and avoiding extra complexity and issues).

This script is good for people who want to test and experiment with their Kubernetes stack config locally (can use snapshots/rollbacks for a quick dev roundtrip) before going to the cloud.

https://github.com/youurayy/hyperctl
