### PR TITLE
Add Octopus testing framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -671,6 +671,7 @@ Projects
 * [Test-Infra](https://github.com/kubernetes/test-infra)
 * [KubeInvaders](https://github.com/lucky-sideburn/KubeInvaders) - Gamified Chaos engineering tool for Kubernetes Clusters. It is like Space Invaders but alien ships are pods.
 * [predator](https://github.com/Zooz/predator) - Distributed performance testing platform for Kubernetes
+* [Octopus](https://github.com/kyma-incubator/octopus) - Octopus is a testing framework that allows you to run integration tests defined as Docker images on a Kubernetes cluster.
 
 ## Continuous Delivery
 


### PR DESCRIPTION
 Octopus is a testing framework that allows you to run integration tests defined as Docker images on a Kubernetes cluster.
It can be replacement for a `helm test`.

Here you can find a blog post that explains why we decided to write this tool and what are the main advantages: https://medium.com/@kymaopensource/how-we-approached-integration-testing-in-kubernetes-and-why-we-stopped-using-helm-tests-e2d3609e6ed9