### PR TITLE
add k8s-label-rules-webhook

### DIFF
--- a/README.md
+++ b/README.md
@@ -597,6 +597,7 @@ Projects
 * [Git Webhook Proxy](https://github.com/stakater/GitWebhookProxy) - A proxy to let webhooks reach running services behind a firewall
 * [Hypernetes](https://github.com/hyperhq/hypernetes)
 * [Ingress Monitor Controller](https://github.com/stakater/IngressMonitorController) - Watches ingress endpoints and automatically registers liveness alerts on the configured uptime checker
+* [k8s-label-rules-webhook](https://github.com/circa10a/k8s-label-rules-webhook) - An admission webhook to enforce standards for labels of resources being created in your k8s cluster
 * [kmachine](https://github.com/skippbox/kmachine)
 * [KEDA](https://github.com/kedacore/keda) - Kubernetes-based Event Driven Autoscaling
 * [kube-fledged](https://github.com/senthilrch/kube-fledged) - A K8S add-on for creating and managing a cache of container images directly on cluster worker nodes


### PR DESCRIPTION
Adding k8s-label-rules-webhook since I haven't seen another application like it available in the kubernetes world.

[k8s-label-rules-webhook documentation](https://github.com/circa10a/k8s-label-rules-webhook)