### PR TITLE
Remove WSO2 from PaaS Section

### DIFF
--- a/README.md
+++ b/README.md
@@ -448,7 +448,6 @@ Managed Kubernetes
   - [Rancher](http://rancher.com/running-kubernetes-aws-rancher/)
   - [RIO](https://rio.io/) - Kubernetes based MicroPaaS
   - [teresa](https://github.com/luizalabs/teresa) - Simple PAAS that runs on top of Kubernetes.
-  - [WSO2](http://wso2.com)
   - [Z.A.R.V.I.S.](https://zarvis.ai) - Deploy Github projects to managed Kubernetes for free
 
 Interactive Learning Environments


### PR DESCRIPTION
Remove WSO2 from PaaS Section, because WSO2 is not PaaS and not usage k8s, wso2 is a integrator and api manager.

Thank You for creating a Pull Request. We appreciate your efforts towards contributing the awesome-kubernetes list.

As a part of our practice, we would like to select the projects based on the below criteria. Please ensure that your submission is fulfilling the below requirements. Thanks

#### Requirements for any project submissions


  - Minimum of 25 GitHub Stars
  - Minimum of 3+ contributors
  - Proper documentation of the project and its goals

#### Exceptions

  - Project is hosted by a recognized organization
