### PR TITLE
Add Classpert courses to MOOCs section

### DIFF
--- a/README.md
+++ b/README.md
@@ -483,6 +483,7 @@ MOOC Courses / Tutorials
   - [Scalable Microservices with Kubernetes at Udacity](http://in.udacity.com/course/scalable-microservices-with-kubernetes--ud615)
   - [Introduction to Kubernetes at edX](http://www.edx.org/course/introduction-kubernetes-linuxfoundationx-lfs158x)
   - [Just Enough Kubernetes to be Dangerous](https://www.schoolofdevops.net/p/just-enough-kubernetes)
+  - [(Classpert) A list of free and paid Kubernetes courses from popular e-learning platforms](https://classpert.com/kubernetes)
 
   ### [Tutorials](#tutorials)
 


### PR DESCRIPTION
This commit adds [Classpert](https://classpert.com/kubernetes) to the section MOOCS/Courses, with a comprehensive selection of 65 Kubernetes courses (free and paid) from providers like Udemy, Pluralsight, Coursera and Skillshare.
