### PR TITLE
Add sample applications section

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ Menu
     - [Public/Private Cloud](#publicprivate-cloud)
     - [PaaS](#paas)
 - [Interactive Learning Environments](#interactive-learning-environments)
+- [Sample Applications](#sample-applications)
 - [MOOC Courses / Tutorials](#mooc-courses--tutorials)
     - [Courses](#courses)
     - [Tutorials](#tutorials)
@@ -155,7 +156,6 @@ Menu
 - [Conferences](#conferences)
 - [Contributing](#contributing)
 - [License](#license)
-
 
 -----------------------------------------------------------------------
 
@@ -471,6 +471,18 @@ Interactive Learning Environments
 * [Kubernetes Bootcamp](http://kubernetesbootcamp.github.io/kubernetes-bootcamp/)
 * [Magic Sandbox](https://magicsandbox.com/)
 * [Play with Kubernetes](http://labs.play-with-k8s.com/)
+
+
+
+Sample Applications
+=======================================================================
+
+*Sample applications to install into your Kubernetes environment*
+
+* [Google samples](https://github.com/GoogleCloudPlatform/kubernetes-engine-samples)
+* [Stan's Robot Shop](https://github.com/instana/robot-shop)
+* [Sock Shop](https://github.com/microservices-demo/microservices-demo)
+
 
 MOOC Courses / Tutorials
 =======================================================================


### PR DESCRIPTION
Added a new section for free sample applications that can be deployed to your Kubernetes cluster to general learning and experimentation. Started with a few I know and use, hopefully other will extend this list.
