### PR TITLE
add kube-eventer to awesome-kubernetes

### DIFF
--- a/README.md
+++ b/README.md
@@ -677,6 +677,7 @@ Projects
 * [kube-state-metrics](https://github.com/kubernetes/kube-state-metrics) - Simple service that listens to the Kubernetes API server and generates metrics about the state of the objects.
 * [loki](https://github.com/grafana/loki) - Loki is a horizontally-scalable, highly-available, multi-tenant log aggregation system inspired by Prometheus.
 * [Loghouse](https://github.com/flant/loghouse) - Efficiently store big amounts of your logs (in ClickHouse database), process them using a simple query language and monitor them online through web UI.
+* [kube-eventer](https://github.com/AliyunContainerService/kube-eventer) - kube-eventer emit kubernetes events to sinks (kafka, slack, webhook, etc)
 
 ## Testing
 


### PR DESCRIPTION
kube-eventer is similar with <a href="https://github.com/heptiolabs/eventrouter">eventrouter</a> but more powerful. Here are some basic information.
- 288 GitHub Stars
- 13 contributors
- document for 11 sinks 
- release v1.0.0 v1.1.0 v1.2.0 and prepare for release v1.3.0

