### PR TITLE
Add VMware Tanzu Kubernetes Grid 

### DIFF
--- a/README.md
+++ b/README.md
@@ -428,8 +428,9 @@ Managed Kubernetes
   - [NetApp Kubernetes Service](https://cloud.netapp.com/kubernetes-service)
   - [OpenShift - Container Platform](http://www.openshift.com/container-platform/index.html)
   - [SUSE Container as a Service](http://www.suse.com/betaprogram/caasp-beta/)
+  - [VMware Tanzu Kubernetes Grid (TKG)](https://tanzu.vmware.com/kubernetes-grid) - Enterprise-ready multi-cloud Kubernetes runtime
   - [WorldSibu-Forma](https://worldsibu.tech/forma/) - Multi-cloud Remote Blockchain Infrastructure Orchestrator with Kubernetes
-  - [VMware Tanzu Kubernetes Grid - TKG](https://tanzu.vmware.com/kubernetes-grid) Enterprise-ready multi-cloud Kubernetes runtime
+  
 
   ### [Public/Private Cloud](#publicprivate-cloud)
 
@@ -818,6 +819,7 @@ Projects
 
 ## Networking
 
+* [Antrea](https://github.com/vmware-tanzu/antrea/) - A Kubernetes networking solution based on Open vSwitch
 * [AWS VPC CNI](https://github.com/aws/amazon-vpc-cni-k8s) - Networking plugin using Elastic Network Interfaces
 * [Calico](http://www.projectcalico.org/)
 * [Canal](https://github.com/tigera/canal) by [Tigera](https://github.com/tigera)

--- a/README.md
+++ b/README.md
@@ -429,6 +429,7 @@ Managed Kubernetes
   - [OpenShift - Container Platform](http://www.openshift.com/container-platform/index.html)
   - [SUSE Container as a Service](http://www.suse.com/betaprogram/caasp-beta/)
   - [WorldSibu-Forma](https://worldsibu.tech/forma/) - Multi-cloud Remote Blockchain Infrastructure Orchestrator with Kubernetes
+  - [VMware Tanzu Kubernetes Grid- TKG](https://tanzu.vmware.com/kubernetes-grid) Enterprise-ready multi-cloud Kubernetes runtime
 
   ### [Public/Private Cloud](#publicprivate-cloud)
 

--- a/README.md
+++ b/README.md
@@ -429,7 +429,7 @@ Managed Kubernetes
   - [OpenShift - Container Platform](http://www.openshift.com/container-platform/index.html)
   - [SUSE Container as a Service](http://www.suse.com/betaprogram/caasp-beta/)
   - [WorldSibu-Forma](https://worldsibu.tech/forma/) - Multi-cloud Remote Blockchain Infrastructure Orchestrator with Kubernetes
-  - [VMware Tanzu Kubernetes Grid- TKG](https://tanzu.vmware.com/kubernetes-grid) Enterprise-ready multi-cloud Kubernetes runtime
+  - [VMware Tanzu Kubernetes Grid - TKG](https://tanzu.vmware.com/kubernetes-grid) Enterprise-ready multi-cloud Kubernetes runtime
 
   ### [Public/Private Cloud](#publicprivate-cloud)
 


### PR DESCRIPTION
Add VMware Tanzu Kubernetes Grid to the the Enterprise products : Project is hosted by a recognized organization.
Add Antrea to Networking : Github project has > 600 stars and 26 contributors

- 
