### PR TITLE
docs: add kconf to CLI tool section

### DIFF
--- a/docs/projects/projects.md
+++ b/docs/projects/projects.md
@@ -304,6 +304,7 @@ Projects
 
 * [awesome-kubectl-plugins](https://github.com/ishantanu/awesome-kubectl-plugins) - Curated list of kubectl plugins.
 * [click](https://github.com/databricks/click) - A CLI focused REPL for quickly interacting with Kubernetes objects.
+* [kconf](https://github.com/particledecay/kconf) - Manage multiple kubeconfigs easily and switch between them
 * [Ksql](https://github.com/brendandburns/ksql)
 * [kube-prompt](https://github.com/c-bata/kube-prompt) - Interactive kubernetes client built using go-prompt.
 * [kube-ps1](https://github.com/jonmosco/kube-ps1) - Kubernetes prompt helper for bash and zsh.


### PR DESCRIPTION
This PR adds [kconf](https://github.com/particledecay/kconf), a command line tool for managing multiple Kubernetes configs easily and in one place. Feature highlights:

- No more need for setting `KUBECONFIG`
- No need to copy configs anywhere
- Add and remove configs with one command
- Quickly switch contexts in any config
- Set default namespace
- Export configs
- Autocomplete in Bash, ZSH, and Fish shells


#### Requirements for any project submissions


  - [x] Minimum of 25 GitHub Stars
  - [x] Minimum of 3+ contributors
  - [x] Proper documentation of the project and its goals

#### Exceptions

  - Project is hosted by a recognized organization