### PR TITLE
Add staroid.com to PaaS section of managed kubernetes

### DIFF
--- a/docs/managed-kubernetes/managed-kubernetes.md
+++ b/docs/managed-kubernetes/managed-kubernetes.md
@@ -79,5 +79,6 @@ Managed Kubernetes
   - [OpenShift Origin (OKD)](http://www.okd.io)
   - [Rancher](http://rancher.com/running-kubernetes-aws-rancher/)
   - [RIO](https://rio.io/) - Kubernetes based MicroPaaS
+  - [Staroid](https://staroid.com) - Managed Kubernetes namespace service that funds open-source projects
   - [teresa](https://github.com/luizalabs/teresa) - Simple PAAS that runs on top of Kubernetes.
   - [Z.A.R.V.I.S.](https://zarvis.ai) - Deploy Github projects to managed Kubernetes for free


### PR DESCRIPTION
I'd like to see If I can add staroid.com to PaaS section of managed kubernetes.