### PR TITLE
Add Kubesh CLI to Projects

### DIFF
--- a/docs/projects/projects.md
+++ b/docs/projects/projects.md
@@ -36,6 +36,7 @@ Projects
 * [k8s-platform-lcm](https://github.com/arminc/k8s-platform-lcm) - A faster and easier way to manage the lifecycle of applications and tools, running and living around your Kubernetes platform
 * [Pixie](https://github.com/pixie-labs/pixie) - Live-debug multi-cluster K8s environments without changing code and moving data off-cluster.
 * [pluto](https://github.com/FairwindsOps/pluto) - A cli tool to help discover deprecated apiVersions in Kubernetes
+* [kubesh](https://github.com/fhivemind/kubesh) - A command-line tool to access Kubernetes nodes via SSH.
 
 ## Package Managers
 


### PR DESCRIPTION
Kubesh is a small python cli utility that allows access to Kubernetes nodes via SSH. It creates a port-forward against a pod running socat, allowing SSH via localhost, and assigns a shell within the cluster.

