### PR TITLE
update lens url and title

### DIFF
--- a/docs/projects/projects.md
+++ b/docs/projects/projects.md
@@ -293,7 +293,7 @@ Projects
 
 * [Kubernetic](https://kubernetic.com/)
 * [Kube Forwarder](http://kube-forwarder.pixelpoint.io) – An open source Kubernetes port forwarding manager
-* [Kontena Lens](https://github.com/kontena/lens) - The Ultimate Dashboard For Kubernetes.
+* [Lens](https://github.com/lensapp/lens) - The Ultimate Dashboard For Kubernetes.
 
 ## Mobile applications
 


### PR DESCRIPTION
Since [Mirantis acquired Kontena](https://containerjournal.com/topics/container-management/mirantis-acquires-open-source-lens-ide-project/).
Kontena is not mentionned anymore.
Hope this help to make this awesome list more accurate.

Thanks !
