### PR TITLE
add KubeLibrary to projects

### DIFF
--- a/docs/projects/projects.md
+++ b/docs/projects/projects.md
@@ -107,6 +107,7 @@ Projects
 * [predator](https://github.com/Zooz/predator) - Distributed performance testing platform for Kubernetes
 * [Octopus](https://github.com/kyma-incubator/octopus) - Octopus is a testing framework that allows you to run integration tests defined as Docker images on a Kubernetes cluster.
 * [KubePug](https://github.com/rikatz/kubepug) - Kubernetes Pre-Upgrade Checker
+* [KubeLibrary](https://github.com/devopsspiral/KubeLibrary) - RobotFramework library for testing Kubernetes cluster
 
 ## Continuous Delivery
 


### PR DESCRIPTION
I'd like to add [KubeLibrary](https://github.com/devopsspiral/KubeLibrary) to testing section of projects .