### PR TITLE
Remove broken blog link

### DIFF
--- a/docs/learning-resources/books.md
+++ b/docs/learning-resources/books.md
@@ -4,7 +4,7 @@ Books
 *A written or printed work consisting of pages glued or sewn together along one side and bound in covers that provide
 us with information*
 
-* [Cloud Native DevOps with Kubernetes](http://shop.oreilly.com/product/0636920175131.do) by [John Arundel](https://twitter.com/bitfield), [Justin Domingus](https://justindomingus.com/) ([blog](https://cloudnativedevopsblog.com))
+* [Cloud Native DevOps with Kubernetes](http://shop.oreilly.com/product/0636920175131.do) by [John Arundel](https://twitter.com/bitfield), [Justin Domingus](https://justindomingus.com/)
 * [Cloud Native Infrastructure](http://cnibook.info) by [Justin Garrison](https://justingarrison.com) and [Kris Nòva](https://www.nivenly.com/)
 * [Container platform for the Enterprise](https://leanpub.com/cpe) by [Armin Coralic](https://twitter.com/acoralic)
 * [DevOps with Kubernetes](https://www.packtpub.com/virtualization-and-cloud/devops-kubernetes) by Hideto Saito, Hui-Chuan Chloe Lee, Cheng-Yang Wu


### PR DESCRIPTION
The blog link for "Cloud Native Devops with Kubernetes" is broken, so It should be removed