### PR TITLE
Add Capact to related Kubernetes projects

### DIFF
--- a/docs/projects/projects.md
+++ b/docs/projects/projects.md
@@ -11,6 +11,7 @@ Projects
 * [Ambassador](http://www.getambassador.io) - API Gateway built on the Envoy Proxy
 * [Argo](https://github.com/argoproj/argo) - The Workflow Engine for Kubernetes
 * [Bitnami Kubernetes Production Runtime](https://kubeprod.io)
+* [Capact](https://github.com/capactio/capact) - A framework to manage applications and infrastructure in a unified way
 * [Client Libraries](https://github.com/kubernetes/website/blob/master/content/en/docs/reference/using-api/client-libraries.md)
 * [Escalator](https://github.com/atlassian/escalator) - A batch or job optimized horizontal autoscaler for Kubernetes
 * [Fairwinds Pluto](https://github.com/FairwindsOps/pluto) - A cli tool to help discover deprecated apiVersions in Kubernetes


### PR DESCRIPTION
Hello,

Capact is a new framework for managing applications and infrastructure (day-one and day-two operations). You can learn more about the concept on the website: https://capact.io
All requirements are met:

  - [x] Minimum of 25 GitHub Stars
  - [x] Minimum of 3+ contributors
  - [x] Proper documentation of the project and its goals

Hope you like it! Cheers!