### PR TITLE
add helmify

### DIFF
--- a/docs/projects/projects.md
+++ b/docs/projects/projects.md
@@ -462,6 +462,7 @@ Projects
 * [kube-libsonnet](https://github.com/bitnami-labs/kube-libsonnet/blob/master/kube.libsonnet) - Generic library of Kubernetes objects for Jsonnet/Kubecfg with object to array mapping for painless overrides.
 * [kubegen](https://github.com/errordeveloper/kubegen) - Reduces the verbosity of Kubernetes resource definitions, and adds macros for templating
 * [kubeval](https://github.com/garethr/kubeval) - CLI tool for validating a Kubernetes YAML or JSON configuration file
+* [helmify](https://github.com/arttor/helmify) - CLI tool to convert K8s YAMLs into a Helm chart
 
 ## Static Analysis
 


### PR DESCRIPTION
[Helmify](https://github.com/arttor/helmify) is a CLI tool to automatically generate Helm charts from K8s manifests.

#### Requirements for any project submissions


  - Minimum of 25 GitHub Stars - 191 ✅ 
  - Minimum of 3+ contributors - 4 ✅ 
  - Proper documentation of the project and its goals - ✅ 
