### PR TITLE
Projects: Add kubernetes-el (Emacs client)

### DIFF
--- a/docs/projects/projects.md
+++ b/docs/projects/projects.md
@@ -341,6 +341,7 @@ Projects
 * [Kubie](https://github.com/sbstp/kubie) - An alternative to kubectx, kubens and the k on prompt modification script
 * [kube-shell](https://github.com/cloudnativelabs/kube-shell) - An integrated shell for working with the Kubernetes CLI
 * [Portainer](https://github.com/portainer/portainer) - Secure REST API proxy to Kubernetes environments, enabling integrations with external tools.
+* [kubernetes-el](https://github.com/kubernetes-el/kubernetes-el) - Kubernetes client for Emacs
 
 ## Application deployment orchestration
 


### PR DESCRIPTION
This PR adds mention of [kubernetes-el](https://github.com/kubernetes-el/kubernetes-el), an Emacs client for Kubernetes cluster management with good adoption (500+ stars). It has had substantial contributions over the years. It is also [extensively documented](https://kubernetes-el.github.io/kubernetes-el/).

Disclaimer: I am one of the co-maintainers of kubernetes-el.