### PR TITLE
Add sveltos to projectlist

### DIFF
--- a/docs/projects/projects.md
+++ b/docs/projects/projects.md
@@ -36,6 +36,7 @@ Projects
 * [Kubernetes Ec2 Autoscaler](https://github.com/openai/kubernetes-ec2-autoscaler)
 * [Kubic-Project](https://github.com/kubic-project)
 * [Reloader](https://github.com/stakater/Reloader) - Auto-load updates of ConfigMaps and Secrets into pods for Deployments, StatefulSets and DaemonSets
+* [Sveltos](https://github.com/projectsveltos) - A project to deploy Kubernetes add-ons in tens of managed clusters.  
 * [Telepresence](http://www.telepresence.io) - Locally develop/debug services against a remote Kubernetes cluster
 * [krane](https://github.com/Shopify/krane) - A command-line tool that helps you ship changes to a Kubernetes namespace and understand the result
 * [ktunnel](https://github.com/omrikiei/ktunnel) - A command-line tool that establishes a reverse tunnel between Kubernetes and your cluster, use it to locally develop/debug services or integrate with local resources.


### PR DESCRIPTION
Sveltos is a project to deploy add-ons (helm charts and/or resource YAMLs) in tens of managed cluster from a management cluster.  It comes with built-in support for ClusterAPI powered clusters. It has ability to decide which add-ons to install based on managed cluster run-time state.

Documentation can be found here: https://projectsveltos.github.io/sveltos 

- [x] Minimum of 25 GitHub Stars
- [x] Minimum of 3+ contributors
- [x] Proper documentation of the project and its goals

If the project is considered worth being listed but location is not correct, happy to update PR.

Thank you!
