### PR TITLE
Added simplyblock to projects

### DIFF
--- a/docs/projects/projects.md
+++ b/docs/projects/projects.md
@@ -561,6 +561,7 @@ Persistent Volume Providers
 * [Rook](http://rook.io/)
 * [StorageOS](http://storageos.com)
 * [Stork](https://github.com/libopenstorage/stork)
+* [simplyblock](https://simplyblock.io)
 
 Container Storage Interface Plugins
 =======================================================================


### PR DESCRIPTION
Simplyblock is not an open source project, hence it would apply to the exception. Simplyblock is a disaggregated, cloud-native storage solution, designed for Kubernetes CSI and NVMe technology from ground up and simplyblock as a company is a CNCF member. I'd appreciate if you could accept the listing.

----
Thank You for creating a Pull Request. We appreciate your efforts towards contributing the awesome-kubernetes list.

As a part of our practice, we would like to select the projects based on the below criteria. Please ensure that your submission is fulfilling the below requirements.

#### Requirements for any project submissions


  - Minimum of 25 GitHub Stars
  - Minimum of 3+ contributors
  - Proper documentation of the project and its goals

#### Exceptions

  - Project is hosted by a recognized organization ✅
