### PR TITLE
Add Kubernetes hand-on labs to Interactive Learning Environments section

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -106,7 +106,6 @@ Starting Point
 * [How to Manage Secrets in Kubernetes – A Complete Guide](https://spacelift.io/blog/kubernetes-secrets)
 * [Kubernetes Concepts: Deep Dive](https://dev.to/idanref/kubernetes-concepts-deep-dive-50en) by [Idan Refaeli](https://www.linkedin.com/in/idan-refaeli-65082a175/)
 * [Fluent Bit with Kubernetes](https://www.manning.com/books/fluent-bit-with-kubernetes) by [Phil Wilkins](https://www.linkedin.com/in/philwilkins/)
-* [Kubernetes Hands-on Labs](https://labex.io/tutorials/quick-start-with-kubernetes-free-tutorials-413796) by [LabEx](https://labex.io)
 
 Contributing
 =======================================================================

--- a/docs/README.md
+++ b/docs/README.md
@@ -106,6 +106,7 @@ Starting Point
 * [How to Manage Secrets in Kubernetes – A Complete Guide](https://spacelift.io/blog/kubernetes-secrets)
 * [Kubernetes Concepts: Deep Dive](https://dev.to/idanref/kubernetes-concepts-deep-dive-50en) by [Idan Refaeli](https://www.linkedin.com/in/idan-refaeli-65082a175/)
 * [Fluent Bit with Kubernetes](https://www.manning.com/books/fluent-bit-with-kubernetes) by [Phil Wilkins](https://www.linkedin.com/in/philwilkins/)
+* [Kubernetes Hands-on Labs](https://labex.io/tutorials/quick-start-with-kubernetes-free-tutorials-413796) by [LabEx](https://labex.io)
 
 Contributing
 =======================================================================

--- a/docs/learning-resources/interactive-environments.md
+++ b/docs/learning-resources/interactive-environments.md
@@ -3,7 +3,7 @@ Interactive Learning Environments
 
 *Learn Kubernetes using an interactive environment without requiring downloads or configuration*
 
-* [LabEx](https://labex.io/skilltrees/kubernetes)
+* [LabEx Kubernetes Labs](https://labex.io/skilltrees/kubernetes)
 * [Kubernetes Bootcamp](http://kubernetesbootcamp.github.io/kubernetes-bootcamp/)
 * [Play with Kubernetes](http://labs.play-with-k8s.com/)
 * [Kubernetes Labs for practice](https://www.sharelearn.net/practice/k8slabs/)

--- a/docs/learning-resources/interactive-environments.md
+++ b/docs/learning-resources/interactive-environments.md
@@ -3,7 +3,7 @@ Interactive Learning Environments
 
 *Learn Kubernetes using an interactive environment without requiring downloads or configuration*
 
-* [Katacoda](http://www.katacoda.com/courses/kubernetes)
+* [LabEx](https://labex.io/skilltrees/kubernetes)
 * [Kubernetes Bootcamp](http://kubernetesbootcamp.github.io/kubernetes-bootcamp/)
 * [Play with Kubernetes](http://labs.play-with-k8s.com/)
 * [Kubernetes Labs for practice](https://www.sharelearn.net/practice/k8slabs/)


### PR DESCRIPTION
I work at LabEx, a unique learning platform that has delivered thousands of linux and devops hands-on labs over the past 7 years. This series of free kubernetes tutorials is designed based on our Hands-on Labs. You can read them without logging in, and all labs can be run on your local machine, making them perfect for beginners.

This repo is a great resource. Please let me know if any changes are needed.