### PR TITLE
Update newsletters.md

### DIFF
--- a/docs/extras/newsletters.md
+++ b/docs/extras/newsletters.md
@@ -3,9 +3,8 @@ Newsletters
 
 *Newsletters with a focus on kubernetes.*
 
-* [KubeWeekly](https://www.cncf.io/kubeweekly/)
+* [CNCF Weekly](https://www.cncf.io/kubeweekly/)
 * [Last Week in Kubernetes Development](http://lwkd.info/)
-* [Learn Kubernetes weekly](https://learnk8s.io/learn-kubernetes-weekly)
-* [Upcoming Kubernetes Events](https://kube.events/newsletter)
+* [Learn Kubernetes weekly](https://learnkube.com/learn-kubernetes-weekly)
 * [Kubelist](https://kubelist.com/)
 * [Learn Cloud Native](https://www.learncloudnative.com/newsletter)


### PR DESCRIPTION
KubeWeekly is no more: https://www.cncf.io/kubeweekly/kubeweekly-434-this-isnt-goodbye-its-just-the-beginning-of-something-even-better/

> Upcoming Kubernetes Events

Only available on LinkedIn: https://www.linkedin.com/newsletters/upcoming-kubernetes-events-7057675831455744000/

Learnk8s is now LearnKube: updated domain