### PR TITLE
Add What Broke Today to Monitoring Services section

### DIFF
--- a/docs/projects/projects.md
+++ b/docs/projects/projects.md
@@ -97,6 +97,7 @@ Projects
 * [Weave Scope](http://www.weave.works/products/weave-scope/)
 * [kube-state-metrics](https://github.com/kubernetes/kube-state-metrics) - Simple service that listens to the Kubernetes API server and generates metrics about the state of the objects.
 * [loki](https://github.com/grafana/loki) - Loki is a horizontally-scalable, highly-available, multi-tenant log aggregation system inspired by Prometheus.
+* [What Broke Today](https://whatbroke.today) - AI-powered outage aggregator tracking 100+ cloud services (GKE, EKS, AKS, etc) with real-time Telegram alerts.
 * [Loghouse](https://github.com/flant/loghouse) - Efficiently store big amounts of your logs (in ClickHouse database), process them using a simple query language and monitor them online through web UI.
 * [kube-eventer](https://github.com/AliyunContainerService/kube-eventer) - kube-eventer emit kubernetes events to sinks (kafka, slack, webhook, etc)
 * [VictoriaMetrics](https://docs.victoriametrics.com/) - VictoriaMetrics: fast, cost-effective monitoring solution and time series database.


### PR DESCRIPTION
## Summary
- Adds [What Broke Today](https://whatbroke.today) to the Monitoring Services section in docs/projects/projects.md

## About What Broke Today
What Broke Today is an AI-powered outage aggregator that:
- Monitors 100+ cloud service status pages in real-time (including GKE, EKS, AKS)
- Uses AI to filter out maintenance/scheduled updates
- Sends instant alerts via Telegram
- Provides a clean web dashboard for browsing incidents

This tool helps Kubernetes operators stay informed about managed Kubernetes service outages.

## Checklist
- [x] Link is working
- [x] Description follows existing format
- [x] Placed in appropriate section (Monitoring Services)