### PR TITLE
Add Kunobi

### DIFF
--- a/docs/projects/projects.md
+++ b/docs/projects/projects.md
@@ -322,6 +322,7 @@ Projects
 * [Kubernetes Insider for Docker Desktop](https://github.com/spurin/kubernetes-insider) - The Kubernetes Insider provides quick and easy access to Kubernetes Pods/Deployments and Services, running in Docker Desktop Kubernetes.
 * [K8Studio](https://github.com/guiqui/k8Studio) - K8Studio is a cross-platform client IDE to manage Kubernetes Clusters.
 * [KFtray](https://github.com/hcavarsan/kftray) - Manage and run multiple kubectl port-forward configurations directly in the menu bar, syncing configurations with git repositories.
+* [Kunobi](https://kunobi.ninja) - Kubernetes desktop IDE with an embedded MCP server, providing visual oversight of AI-driven cluster operations. Supports FluxCD, ArgoCD, Helm, and expanding to infrastructure beyond Kubernetes.
 
 ## Mobile applications
 


### PR DESCRIPTION
## What is Kunobi?

[Kunobi](https://kunobi.ninja) is a desktop platform management IDE for Kubernetes. GitOps, simplified.

Built with Rust and React, it provides real-time visual oversight of your clusters, FluxCD, ArgoCD, and Helm — not just another kubectl wrapper.

**Key features:**

- Real-time cluster visibility with resource browser, YAML editor, and embedded terminal
- Native FluxCD, ArgoCD, and Helm support
- Built-in MCP server so AI assistants (Claude Code, Codex CLI, Gemini CLI) can manage your clusters
- Available on macOS, Windows, and Linux
- No account required, no cloud dependency

![Kunobi](https://raw.githubusercontent.com/kunobi-ninja/mcp/main/assets/main.png)

![Kunobi — Cluster view](https://raw.githubusercontent.com/kunobi-ninja/mcp/main/assets/nodes.png)

**Built-in MCP support:**

Kunobi has an embedded MCP HTTP server. Enable it in Settings > AI & MCP, and AI assistants can manage your clusters while you maintain full visual oversight.

![Kunobi — MCP settings](https://raw.githubusercontent.com/kunobi-ninja/mcp/main/assets/mcp.png)

**Website:** https://kunobi.ninja
**npm:** [@kunobi/mcp](https://www.npmjs.com/package/@kunobi/mcp)