### PR TITLE
Add n01d-docker to Security section

### DIFF
--- a/docs/projects/projects.md
+++ b/docs/projects/projects.md
@@ -416,6 +416,7 @@ Projects
 * [Guard](https://github.com/appscode/guard) - Authenticaton webhook server with support for Github, Gitlab, Google, Azure and LDAP (AD) as identity providers.
 * [kiam](https://github.com/uswitch/kiam) -  Allows cluster users to associate AWS IAM roles to Pods.
 * [kube-bench](https://github.com/aquasecurity/kube-bench) - The Kubernetes Bench for Security is a Go application that checks whether Kubernetes is deployed according to security best practices.
+* [n01d-docker](https://github.com/bad-antics/n01d-docker) - Security-focused Docker Compose stacks for pentest, CTF, and security research with Kali, Metasploit, Nuclei, and proxy containers.
 * [kube-hunter](https://github.com/aquasecurity/kube-hunter) - Hunt for security weaknesses in Kubernetes clusters.
 * [kube-psp-advisor](https://github.com/sysdiglabs/kube-psp-advisor) - Help building an adaptive and fine-grained pod security policy.
 * [kube2iam](https://github.com/jtblin/kube2iam) - Provides different AWS IAM roles for pods running on Kubernetes


### PR DESCRIPTION
## Description
Adds [n01d-docker](https://github.com/bad-antics/n01d-docker) to the Security section in projects.

## What is n01d-docker?
A collection of security-focused Docker Compose stacks:

### Available Stacks
| Stack | Purpose |
|-------|---------|
| Pentest | Kali, Metasploit, Burp Suite, Nuclei |
| CTF | Competition-ready security environment |
| Development | Python, Julia, Rust containers |
| Proxy/VPN | Network security tools |

### Use Cases
- Kubernetes security testing (using containerized tools)
- Container security research
- CTF competitions
- Security training environments

## Checklist
- [x] Follows contribution guidelines
- [x] Link is valid
- [x] Project is actively maintained
- [x] Placed in appropriate section