### PR TITLE
Add BunkerWeb to Load balancing section

### DIFF
--- a/docs/projects/projects.md
+++ b/docs/projects/projects.md
@@ -434,6 +434,7 @@ Projects
 * [Apache APISIX - Cloud-Native API gateway and ingress controller](https://github.com/apache/apisix)
 * [Avi Networks - Software Load Balancer | Intelligent WAF | Elastic Service Mesh](https://avinetworks.com/)
 * [AWS ALB Ingress Controller](https://github.com/kubernetes-sigs/aws-alb-ingress-controller)
+* [BunkerWeb](https://github.com/bunkerity/bunkerweb) - A next-generation, open-source Web Application Firewall (WAF) with an Ingress Controller and a Gateway API controller.
 * [Cloudflare Warp Ingress](https://github.com/cloudflare/cloudflare-ingress-controller)
 * [Contour](https://github.com/projectcontour/contour) - Kubernetes ingress controller for Lyft's Envoy proxy
 * [F5 Big IP Controller](https://github.com/F5Networks/k8s-bigip-ctlr)


### PR DESCRIPTION
Hello!

I would like to add [BunkerWeb](https://github.com/bunkerity/bunkerweb) to the **Load balancing** section of the Awesome-Kubernetes list.

BunkerWeb is a next-generation, open-source Web Application Firewall (WAF). In a Kubernetes environment, its `bunkerweb-autoconf` service acts as an Ingress Controller and supports the Gateway API. It fits well within the Load balancing category alongside other Ingress solutions.

**Contribution Criteria Checklist:**
- [x] Minimum of 25 GitHub Stars (BunkerWeb has > 9k stars)
- [x] Minimum of 3+ contributors (BunkerWeb has > 40 contributors)
- [x] Proper documentation (https://docs.bunkerweb.io)

I have ensured the entry is sorted alphabetically.

Thank you for reviewing!
