### PR TITLE
Add Kanvas - CNCF Meshery Visual Infrastructure Designer

### DIFF
--- a/docs/projects/projects.md
+++ b/docs/projects/projects.md
@@ -25,6 +25,7 @@ Projects
 * [Hypernetes](https://github.com/hyperhq/hypernetes)
 * [Ingress Monitor Controller](https://github.com/stakater/IngressMonitorController) - Watches ingress endpoints and automatically registers liveness alerts on the configured uptime checker
 * [k8s-label-rules-webhook](https://github.com/circa10a/k8s-label-rules-webhook) - An admission webhook to enforce standards for labels of resources being created in your k8s cluster
+* [Kanvas](https://github.com/meshery/kanvas) - A collaborative visual designer for Kubernetes and multi-cloud infrastructure.
 * [kmachine](https://github.com/skippbox/kmachine)
 * [KEDA](https://github.com/kedacore/keda) - Kubernetes-based Event Driven Autoscaling
 * [kube-fledged](https://github.com/senthilrch/kube-fledged) - A K8S add-on for creating and managing a cache of container images directly on cluster worker nodes

--- a/docs/projects/projects.md
+++ b/docs/projects/projects.md
@@ -25,7 +25,7 @@ Projects
 * [Hypernetes](https://github.com/hyperhq/hypernetes)
 * [Ingress Monitor Controller](https://github.com/stakater/IngressMonitorController) - Watches ingress endpoints and automatically registers liveness alerts on the configured uptime checker
 * [k8s-label-rules-webhook](https://github.com/circa10a/k8s-label-rules-webhook) - An admission webhook to enforce standards for labels of resources being created in your k8s cluster
-* [Kanvas](https://github.com/meshery/kanvas) - A collaborative visual designer for Kubernetes and multi-cloud infrastructure.
+* [Kanvas](https://github.com/meshery-extensions/kanvas-site) - A collaborative visual designer for Kubernetes and multi-cloud infrastructure.
 * [kmachine](https://github.com/skippbox/kmachine)
 * [KEDA](https://github.com/kedacore/keda) - Kubernetes-based Event Driven Autoscaling
 * [kube-fledged](https://github.com/senthilrch/kube-fledged) - A K8S add-on for creating and managing a cache of container images directly on cluster worker nodes


### PR DESCRIPTION
Project Details:

Project Name: Kanvas

GitHub Link: https://github.com/meshery-extensions/kanvas-site 

Description: A collaborative visual designer for Kubernetes and multi-cloud infrastructure.
