### PR TITLE
Add Thanos to Monitoring Services section

### DIFF
--- a/docs/projects/projects.md
+++ b/docs/projects/projects.md
@@ -93,6 +93,7 @@ Projects
 * [StatusBay](https://github.com/similarweb/statusbay) - Kubernetes deployment visibility (inc. Slack notifications, metrics and checks enrichment, resources consolidation, etc)
 * [Sysdig Monitoring](https://www.sysdig.com/)
 * [Sysdig Open Source](http://www.sysdig.org/)
+* [Thanos](https://github.com/thanos-io/thanos) - Highly available Prometheus setup with long term storage capabilities
 * [The Elastic Stack](https://www.elastic.co/docker-kubernetes-container-monitoring) - An open-source solution for monitoring and visualising K8s metrics, logs, application traces and more.
 * [Weave Scope](http://www.weave.works/products/weave-scope/)
 * [kube-state-metrics](https://github.com/kubernetes/kube-state-metrics) - Simple service that listens to the Kubernetes API server and generates metrics about the state of the objects.


### PR DESCRIPTION
## Description
Added Thanos to the Monitoring Services section.

## Why this addition is valuable
Thanos is a widely adopted open-source project that extends Prometheus with:
- Long-term storage capabilities
- High availability setup
- Global query view
- 12,000+ GitHub stars
- Active maintenance by the CNCF community

I have used Thanos in production Kubernetes environments for distributed monitoring and found it extremely valuable for large-scale deployments.

## Checklist
- [x] Tool has 25+ GitHub Stars (12k+)
- [x] Tool has 3+ contributors (hundreds)
- [x] Proper documentation exists
- [x] Added to appropriate section in alphabetical order
- [x] Follows existing format