### PR TITLE
Add ReleaseRun Badges to Monitoring Services

### DIFF
--- a/docs/projects/projects.md
+++ b/docs/projects/projects.md
@@ -103,6 +103,7 @@ Projects
 * [kube-eventer](https://github.com/AliyunContainerService/kube-eventer) - kube-eventer emit kubernetes events to sinks (kafka, slack, webhook, etc)
 * [VictoriaMetrics](https://docs.victoriametrics.com/) - VictoriaMetrics: fast, cost-effective monitoring solution and time series database.
 * [VictoriaLogs](https://docs.victoriametrics.com/victorialogs/) - VictoriaLogs is a fast and easy-to-use, open source logs solution. Highly scalable on cloud, kubernetes or on-premise setups.
+* [ReleaseRun Badges](https://releaserun.com/badges/) - Embeddable version health, CVE count, and EOL countdown badges for Kubernetes versions and cloud providers (EKS, GKE, AKS). Useful for READMEs and docs.
 
 ## Testing
 


### PR DESCRIPTION
Adding ReleaseRun Badges to the Monitoring Services section. They provide embeddable SVG badges for Kubernetes version health, CVE counts per version, and EOL countdowns. Also covers cloud provider versions (EKS, GKE, AKS).

Handy for project READMEs and documentation sites where you want to show which K8s versions you support and their security status.

Examples:
- Version health: img.releaserun.com/badge/health/kubernetes.svg
- CVE count: img.releaserun.com/badge/cve/kubernetes/1.35.svg
- EOL status: img.releaserun.com/badge/eol/kubernetes/1.32.svg

Free, no API key required. Supports 300+ products beyond just Kubernetes.