### PR TITLE
Add ReleaseRun Kubernetes version health badges

### DIFF
--- a/docs/projects/projects.md
+++ b/docs/projects/projects.md
@@ -86,6 +86,7 @@ Projects
 * [New Relic](https://newrelic.com/platform/kubernetes) - Kubernetes monitoring and visualization service.
 * [NexClipper](https://github.com/NexClipper/NexClipper) - An open source software for monitoring Kubernetes and containers.
 * [Outcold Solutions](https://www.outcoldsolutions.com) - monitoring Kubernetes, OpenShift and Docker in Splunk Enterprise and Splunk Cloud (metrics and log forwarding)
+* [ReleaseRun K8s Badges](https://releaserun.com/badges/builder/) - Embeddable badges showing Kubernetes version health, CVE counts, EOL status, and EKS/GKE/AKS cloud provider support.
 * [Prometheus](http://prometheus.io)
 * [Replex.io](https://replex.io) - Kubernetes Governance & Cost Control.
 * [Robusta.dev](https://github.com/robusta-dev/robusta) - Better Prometheus Alerts for Kubernetes with ability to Enrich, Group, and Remediate your Alerts.

--- a/docs/projects/projects.md
+++ b/docs/projects/projects.md
@@ -86,8 +86,8 @@ Projects
 * [New Relic](https://newrelic.com/platform/kubernetes) - Kubernetes monitoring and visualization service.
 * [NexClipper](https://github.com/NexClipper/NexClipper) - An open source software for monitoring Kubernetes and containers.
 * [Outcold Solutions](https://www.outcoldsolutions.com) - monitoring Kubernetes, OpenShift and Docker in Splunk Enterprise and Splunk Cloud (metrics and log forwarding)
-* [ReleaseRun K8s Badges](https://releaserun.com/badges/builder/) - Embeddable badges showing Kubernetes version health, CVE counts, EOL status, and EKS/GKE/AKS cloud provider support.
 * [Prometheus](http://prometheus.io)
+* [ReleaseRun K8s Badges](https://releaserun.com/badges/builder/) - Embeddable badges showing Kubernetes version health, CVE counts, EOL status, and EKS/GKE/AKS cloud provider support.
 * [Replex.io](https://replex.io) - Kubernetes Governance & Cost Control.
 * [Robusta.dev](https://github.com/robusta-dev/robusta) - Better Prometheus Alerts for Kubernetes with ability to Enrich, Group, and Remediate your Alerts.
 * [Searchlight](https://github.com/appscode/searchlight)


### PR DESCRIPTION
ReleaseRun provides embeddable SVG badges for Kubernetes version monitoring:

- **Health badges**: overall version health score (A-F grade)
- **EOL badges**: days remaining until end-of-life
- **CVE badges**: known vulnerability counts per version
- **Cloud provider support**: EKS, GKE, AKS version availability

Example:
![K8s Health](https://img.releaserun.com/badge/health/kubernetes.svg)
![K8s 1.34 EOL](https://img.releaserun.com/badge/eol/kubernetes/1.34.svg)

Useful for README version documentation, runbook/wiki version status displays, and CI dashboards showing infrastructure currency.

Badge builder: https://releaserun.com/badges/builder/
GitHub Action: https://github.com/Matheus-RR/badges