### PR TITLE
Add Kubernetes Deprecation Checker to Security section

### DIFF
--- a/docs/projects/projects.md
+++ b/docs/projects/projects.md
@@ -86,6 +86,7 @@ Projects
 * [New Relic](https://newrelic.com/platform/kubernetes) - Kubernetes monitoring and visualization service.
 * [NexClipper](https://github.com/NexClipper/NexClipper) - An open source software for monitoring Kubernetes and containers.
 * [Outcold Solutions](https://www.outcoldsolutions.com) - monitoring Kubernetes, OpenShift and Docker in Splunk Enterprise and Splunk Cloud (metrics and log forwarding)
+* [ReleaseRun K8s Badges](https://releaserun.com/badges/builder/) - Embeddable badges showing Kubernetes version health, CVE counts, EOL status, and EKS/GKE/AKS cloud provider support.
 * [Prometheus](http://prometheus.io)
 * [Replex.io](https://replex.io) - Kubernetes Governance & Cost Control.
 * [Robusta.dev](https://github.com/robusta-dev/robusta) - Better Prometheus Alerts for Kubernetes with ability to Enrich, Group, and Remediate your Alerts.

--- a/docs/projects/projects.md
+++ b/docs/projects/projects.md
@@ -86,8 +86,8 @@ Projects
 * [New Relic](https://newrelic.com/platform/kubernetes) - Kubernetes monitoring and visualization service.
 * [NexClipper](https://github.com/NexClipper/NexClipper) - An open source software for monitoring Kubernetes and containers.
 * [Outcold Solutions](https://www.outcoldsolutions.com) - monitoring Kubernetes, OpenShift and Docker in Splunk Enterprise and Splunk Cloud (metrics and log forwarding)
-* [ReleaseRun K8s Badges](https://releaserun.com/badges/builder/) - Embeddable badges showing Kubernetes version health, CVE counts, EOL status, and EKS/GKE/AKS cloud provider support.
 * [Prometheus](http://prometheus.io)
+* [ReleaseRun K8s Badges](https://releaserun.com/badges/builder/) - Embeddable badges showing Kubernetes version health, CVE counts, EOL status, and EKS/GKE/AKS cloud provider support.
 * [Replex.io](https://replex.io) - Kubernetes Governance & Cost Control.
 * [Robusta.dev](https://github.com/robusta-dev/robusta) - Better Prometheus Alerts for Kubernetes with ability to Enrich, Group, and Remediate your Alerts.
 * [Searchlight](https://github.com/appscode/searchlight)

--- a/docs/projects/projects.md
+++ b/docs/projects/projects.md
@@ -421,6 +421,7 @@ Projects
 * [kiam](https://github.com/uswitch/kiam) -  Allows cluster users to associate AWS IAM roles to Pods.
 * [kube-bench](https://github.com/aquasecurity/kube-bench) - The Kubernetes Bench for Security is a Go application that checks whether Kubernetes is deployed according to security best practices.
 * [kube-hunter](https://github.com/aquasecurity/kube-hunter) - Hunt for security weaknesses in Kubernetes clusters.
+* [Kubernetes Deprecation Checker](https://releaserun.com/tools/k8s-deprecation-checker/) - Free browser-based tool that scans Kubernetes YAML manifests for deprecated and removed API versions, with migration paths and fix suggestions.
 * [kube-psp-advisor](https://github.com/sysdiglabs/kube-psp-advisor) - Help building an adaptive and fine-grained pod security policy.
 * [kube2iam](https://github.com/jtblin/kube2iam) - Provides different AWS IAM roles for pods running on Kubernetes
 * [kubeaudit](https://github.com/Shopify/kubeaudit) - Helps you audit your Kubernetes clusters against common security controls


### PR DESCRIPTION
Adding a free Kubernetes deprecation checker tool to the Security section.

**What it does:**
- Scans Kubernetes YAML manifests for deprecated and removed API versions
- Shows which API version to migrate to for each resource
- Covers all deprecations from Kubernetes 1.16 through 1.32
- Runs entirely in the browser with no install or signup

**Link:** https://releaserun.com/tools/k8s-deprecation-checker/

Useful for teams preparing cluster upgrades who need to audit their manifests for breaking API changes. Fits alongside the other security/audit tools in this section (kubeaudit, kube-bench, kube-hunter).

Happy to adjust placement if you think it fits better elsewhere. Thanks!