### PR TITLE
Add Ingero - eBPF-based GPU observability for Kubernetes

### DIFF
--- a/docs/projects/projects.md
+++ b/docs/projects/projects.md
@@ -68,6 +68,7 @@ Projects
 * [Heapster](https://github.com/kubernetes/heapster)
 * [HolmesGPT](https://github.com/robusta-dev/holmesgpt) - On-Call/DevOps Assistant - Get a head start on fixing alerts with AI. Investigate Prometheus alerts, Jira/Pagerduty/Opsgenie tickets automatically.
 * [Instana](https://www.instana.com/) - Automatic Kubernetes Application Performance Monitoring
+* [Ingero](https://github.com/ingero-io/ingero) - eBPF-based GPU causal observability agent for Kubernetes. Traces CUDA Runtime/Driver APIs and host kernel events with pod/namespace metadata enrichment. DaemonSet + Helm chart included.
 * [kite](https://github.com/zxh326/kite) - A modern, lightweight Kubernetes dashboard.
 * [kail](https://github.com/boz/kail) - Kubernetes Log Viewer. Streams logs from all containers of all matching pods.
 * [KRR](https://github.com/robusta-dev/krr) - Kubernetes CPU/Memory requests/limits recommendations based on existing data in Prometheus/Coralogix/Thanos/Mimir and more!


### PR DESCRIPTION
Ingero is an eBPF-based GPU causal observability agent with Kubernetes support (DaemonSet, Helm chart, pod/namespace metadata enrichment). Traces CUDA Runtime/Driver APIs via uprobes and host kernel events via tracepoints. <2% overhead. https://github.com/ingero-io/ingero