### PR TITLE
Add ReleaseRun K8s Badges to Monitoring Services

### DIFF
--- a/docs/projects/projects.md
+++ b/docs/projects/projects.md
@@ -86,6 +86,7 @@ Projects
 * [New Relic](https://newrelic.com/platform/kubernetes) - Kubernetes monitoring and visualization service.
 * [NexClipper](https://github.com/NexClipper/NexClipper) - An open source software for monitoring Kubernetes and containers.
 * [Outcold Solutions](https://www.outcoldsolutions.com) - monitoring Kubernetes, OpenShift and Docker in Splunk Enterprise and Splunk Cloud (metrics and log forwarding)
+* [ReleaseRun K8s Badges](https://releaserun.com/badges/builder/) - Embeddable badges showing Kubernetes version health, CVE counts, EOL status, and EKS/GKE/AKS cloud provider support.
 * [Prometheus](http://prometheus.io)
 * [Replex.io](https://replex.io) - Kubernetes Governance & Cost Control.
 * [Robusta.dev](https://github.com/robusta-dev/robusta) - Better Prometheus Alerts for Kubernetes with ability to Enrich, Group, and Remediate your Alerts.

--- a/docs/projects/projects.md
+++ b/docs/projects/projects.md
@@ -86,8 +86,8 @@ Projects
 * [New Relic](https://newrelic.com/platform/kubernetes) - Kubernetes monitoring and visualization service.
 * [NexClipper](https://github.com/NexClipper/NexClipper) - An open source software for monitoring Kubernetes and containers.
 * [Outcold Solutions](https://www.outcoldsolutions.com) - monitoring Kubernetes, OpenShift and Docker in Splunk Enterprise and Splunk Cloud (metrics and log forwarding)
-* [ReleaseRun K8s Badges](https://releaserun.com/badges/builder/) - Embeddable badges showing Kubernetes version health, CVE counts, EOL status, and EKS/GKE/AKS cloud provider support.
 * [Prometheus](http://prometheus.io)
+* [ReleaseRun K8s Badges](https://releaserun.com/badges/builder/) - Embeddable badges showing Kubernetes version health, CVE counts, EOL status, and EKS/GKE/AKS cloud provider support.
 * [Replex.io](https://replex.io) - Kubernetes Governance & Cost Control.
 * [Robusta.dev](https://github.com/robusta-dev/robusta) - Better Prometheus Alerts for Kubernetes with ability to Enrich, Group, and Remediate your Alerts.
 * [Searchlight](https://github.com/appscode/searchlight)


### PR DESCRIPTION
Adds embeddable Kubernetes health badges to the Monitoring Services section.

Shows K8s version EOL status, CVE count, and cloud provider support (EKS/GKE/AKS). Free, no signup required: https://releaserun.com/badges/builder/

The badge builder lets you generate markdown/HTML embed snippets for any Kubernetes version in seconds.