### PR TITLE
Add Kubernetes Deprecation Checker to Security

### DIFF
--- a/docs/projects/projects.md
+++ b/docs/projects/projects.md
@@ -86,6 +86,7 @@ Projects
 * [New Relic](https://newrelic.com/platform/kubernetes) - Kubernetes monitoring and visualization service.
 * [NexClipper](https://github.com/NexClipper/NexClipper) - An open source software for monitoring Kubernetes and containers.
 * [Outcold Solutions](https://www.outcoldsolutions.com) - monitoring Kubernetes, OpenShift and Docker in Splunk Enterprise and Splunk Cloud (metrics and log forwarding)
+* [ReleaseRun K8s Badges](https://releaserun.com/badges/builder/) - Embeddable badges showing Kubernetes version health, CVE counts, EOL status, and EKS/GKE/AKS cloud provider support.
 * [Prometheus](http://prometheus.io)
 * [Replex.io](https://replex.io) - Kubernetes Governance & Cost Control.
 * [Robusta.dev](https://github.com/robusta-dev/robusta) - Better Prometheus Alerts for Kubernetes with ability to Enrich, Group, and Remediate your Alerts.

--- a/docs/projects/projects.md
+++ b/docs/projects/projects.md
@@ -86,8 +86,8 @@ Projects
 * [New Relic](https://newrelic.com/platform/kubernetes) - Kubernetes monitoring and visualization service.
 * [NexClipper](https://github.com/NexClipper/NexClipper) - An open source software for monitoring Kubernetes and containers.
 * [Outcold Solutions](https://www.outcoldsolutions.com) - monitoring Kubernetes, OpenShift and Docker in Splunk Enterprise and Splunk Cloud (metrics and log forwarding)
-* [ReleaseRun K8s Badges](https://releaserun.com/badges/builder/) - Embeddable badges showing Kubernetes version health, CVE counts, EOL status, and EKS/GKE/AKS cloud provider support.
 * [Prometheus](http://prometheus.io)
+* [ReleaseRun K8s Badges](https://releaserun.com/badges/builder/) - Embeddable badges showing Kubernetes version health, CVE counts, EOL status, and EKS/GKE/AKS cloud provider support.
 * [Replex.io](https://replex.io) - Kubernetes Governance & Cost Control.
 * [Robusta.dev](https://github.com/robusta-dev/robusta) - Better Prometheus Alerts for Kubernetes with ability to Enrich, Group, and Remediate your Alerts.
 * [Searchlight](https://github.com/appscode/searchlight)

--- a/docs/projects/projects.md
+++ b/docs/projects/projects.md
@@ -88,7 +88,6 @@ Projects
 * [NexClipper](https://github.com/NexClipper/NexClipper) - An open source software for monitoring Kubernetes and containers.
 * [Outcold Solutions](https://www.outcoldsolutions.com) - monitoring Kubernetes, OpenShift and Docker in Splunk Enterprise and Splunk Cloud (metrics and log forwarding)
 * [Prometheus](http://prometheus.io)
-* [ReleaseRun K8s Badges](https://releaserun.com/badges/builder/) - Embeddable badges showing Kubernetes version health, CVE counts, EOL status, and EKS/GKE/AKS cloud provider support.
 * [Replex.io](https://replex.io) - Kubernetes Governance & Cost Control.
 * [Robusta.dev](https://github.com/robusta-dev/robusta) - Better Prometheus Alerts for Kubernetes with ability to Enrich, Group, and Remediate your Alerts.
 * [Searchlight](https://github.com/appscode/searchlight)
@@ -420,6 +419,7 @@ Projects
 * [Fairwinds Insights](https://fairwinds.com/insights) - Security policy and enforcement for Kubernetes
 * [Guard](https://github.com/appscode/guard) - Authenticaton webhook server with support for Github, Gitlab, Google, Azure and LDAP (AD) as identity providers.
 * [kiam](https://github.com/uswitch/kiam) -  Allows cluster users to associate AWS IAM roles to Pods.
+* [Kubernetes Deprecation Checker](https://releaserun.com/tools/k8s-deprecation-checker/) - Free browser-based tool that scans Kubernetes YAML manifests for deprecated and removed API versions, with migration paths and fix suggestions.
 * [kube-bench](https://github.com/aquasecurity/kube-bench) - The Kubernetes Bench for Security is a Go application that checks whether Kubernetes is deployed according to security best practices.
 * [kube-hunter](https://github.com/aquasecurity/kube-hunter) - Hunt for security weaknesses in Kubernetes clusters.
 * [kube-psp-advisor](https://github.com/sysdiglabs/kube-psp-advisor) - Help building an adaptive and fine-grained pod security policy.


### PR DESCRIPTION
Adds a free browser-based K8s YAML deprecation checker to the Security section. Scans manifests for removed/deprecated API versions across K8s 1.16–1.35, with migration paths and auto-fix suggestions. No install, no signup: https://releaserun.com/tools/k8s-deprecation-checker/