### PR TITLE
Add bitwarden-csi-provider to Secret generation and management

### DIFF
--- a/docs/projects/projects.md
+++ b/docs/projects/projects.md
@@ -293,6 +293,7 @@ Projects
 
 ## Secret generation and management
 
+* [bitwarden-csi-provider](https://github.com/kvncrw/bitwarden-csi-provider) - Bitwarden Secrets Manager provider for the Kubernetes Secrets Store CSI Driver
 * [CyberArk Conjur Kubernetes Authenticator](https://developer.conjur.net/reference/integrations/kubernetesopenshift.html) - Secure your Kubernetes-deployed applications with CyberArk Conjur
 * [External Secrets Operator](https://github.com/external-secrets/external-secrets/)
 * [k8sec](https://github.com/dtan4/k8sec)


### PR DESCRIPTION
## Summary

- Adds [bitwarden-csi-provider](https://github.com/kvncrw/bitwarden-csi-provider) to the "Secret generation and management" section in `docs/projects/projects.md`
- bitwarden-csi-provider is a Bitwarden Secrets Manager provider for the Kubernetes Secrets Store CSI Driver, enabling Kubernetes workloads to consume Bitwarden secrets via the standard CSI interface
- Entry placed in alphabetical order within the existing list