### PR TITLE
Add Jupyter Notebook Validator Operator to Operators

### DIFF
--- a/docs/projects/projects.md
+++ b/docs/projects/projects.md
@@ -185,6 +185,7 @@ Projects
 * [Elasticsearch](https://github.com/upmc-enterprises/elasticsearch-operator)
 * [etcd](https://github.com/coreos/etcd-operator)
 * [Istio](https://github.com/banzaicloud/istio-operator)
+* [Jupyter Notebook Validator Operator](https://github.com/tosin2013/jupyter-notebook-validator-operator) - Kubernetes operator for validating Jupyter notebooks in MLOps workflows (Papermill, golden notebooks, model validation); published on [OperatorHub.io](https://operatorhub.io/operator/jupyter-notebook-validator-operator).
 * [K8s Operator Workshop](https://github.com/lukebond/cc-au-k8s-operators-workshop)
 * [k8tz](https://github.com/k8tz/k8tz) - Kubernetes admission controller and a CLI tool to inject timezones into Pods and CronJobs
 * [Kafka](https://github.com/krallistic/kafka-operator)


### PR DESCRIPTION
## Summary
Adds [Jupyter Notebook Validator Operator](https://github.com/tosin2013/jupyter-notebook-validator-operator) under **Operators** in `docs/projects/projects.md`.

## About the project
- Kubernetes-native operator (Operator SDK) for validating Jupyter notebooks in MLOps: Papermill execution, golden notebook comparison, Git integration, model-aware validation.
- Listed on [OperatorHub.io](https://operatorhub.io/operator/jupyter-notebook-validator-operator).

## Submission criteria
The repo notes a minimum of 25 stars / 3+ contributors; this project is still growing. If that is a blocker, please consider the **Exceptions** clause (recognized organization / OperatorHub distribution) or we can close and resubmit later.

## Checklist
- [x] Single link, description on same line (per CONTRIBUTING)
- [x] Category: Operators

Made with [Cursor](https://cursor.com)