### PR TITLE
Add kpod-metrics to Monitoring Services

### DIFF
--- a/docs/projects/projects.md
+++ b/docs/projects/projects.md
@@ -70,6 +70,7 @@ Projects
 * [Instana](https://www.instana.com/) - Automatic Kubernetes Application Performance Monitoring
 * [kite](https://github.com/zxh326/kite) - A modern, lightweight Kubernetes dashboard.
 * [kail](https://github.com/boz/kail) - Kubernetes Log Viewer. Streams logs from all containers of all matching pods.
+* [kpod-metrics](https://github.com/pjs7678/kpod-metrics) - eBPF-based pod-level kernel metrics collector that exports per-pod CPU, network, memory, syscall, and disk I/O metrics to Prometheus. Zero instrumentation required.
 * [KRR](https://github.com/robusta-dev/krr) - Kubernetes CPU/Memory requests/limits recommendations based on existing data in Prometheus/Coralogix/Thanos/Mimir and more!
 * [Kubebox](https://github.com/astefanutti/kubebox) - Terminal console for Kubernetes
 * [Kubecost](https://kubecost.com/) - monitor resources following their financial cost


### PR DESCRIPTION
[kpod-metrics](https://github.com/pjs7678/kpod-metrics) is an eBPF-based pod-level kernel metrics collector for Kubernetes.

- DaemonSet that exports per-pod CPU, network, memory, syscall, and disk I/O metrics to Prometheus
- Zero instrumentation — eBPF attaches to kernel tracepoints automatically
- L7 protocol detection (HTTP, DNS, Redis, MySQL, Kafka, MongoDB)
- Auto-discovered service topology
- Helm chart available

Added to the **Monitoring Services** section.