### PR TITLE
Add k8s4claw — Kubernetes operator for AI agent runtimes

### DIFF
--- a/docs/projects/projects.md
+++ b/docs/projects/projects.md
@@ -186,6 +186,7 @@ Projects
 * [etcd](https://github.com/coreos/etcd-operator)
 * [Istio](https://github.com/banzaicloud/istio-operator)
 * [K8s Operator Workshop](https://github.com/lukebond/cc-au-k8s-operators-workshop)
+* [k8s4claw](https://github.com/Prismer-AI/k8s4claw) - Kubernetes operator for managing heterogeneous AI agent runtimes with a single CRD — IPC bus, channel sidecars, auto-updates, and persistence.
 * [k8tz](https://github.com/k8tz/k8tz) - Kubernetes admission controller and a CLI tool to inject timezones into Pods and CronJobs
 * [Kafka](https://github.com/krallistic/kafka-operator)
 * [Kong API](https://github.com/upmc-enterprises/kong-operator)


### PR DESCRIPTION
## What

Add [k8s4claw](https://github.com/Prismer-AI/k8s4claw) to the Operators section.

## Description

k8s4claw is a Kubernetes operator for managing heterogeneous AI agent runtimes. One CRD manages the full lifecycle: StatefulSet, Service, ConfigMap, IPC Bus (WAL + DLQ + backpressure), channel sidecars (Slack, Discord, Webhook), auto-updates with circuit breaker, PVC persistence, and CSI snapshots.

- **5 built-in runtimes** — OpenClaw, NanoClaw, ZeroClaw, PicoClaw, IronClaw
- **Go SDK** for programmatic access
- **Helm chart** with cert-manager integration
- **80%+ test coverage** across all packages
- **Apache-2.0** licensed

GitHub: https://github.com/Prismer-AI/k8s4claw