### PR TITLE
Add Qovery — Kubernetes management platform with Terraform, CLI, and AI Agent Skill

### DIFF
--- a/docs/projects/projects.md
+++ b/docs/projects/projects.md
@@ -42,6 +42,7 @@ Projects
 * [ktunnel](https://github.com/omrikiei/ktunnel) - A command-line tool that establishes a reverse tunnel between Kubernetes and your cluster, use it to locally develop/debug services or integrate with local resources.
 * [k8s-platform-lcm](https://github.com/arminc/k8s-platform-lcm) - A faster and easier way to manage the lifecycle of applications and tools, running and living around your Kubernetes platform
 * [Pixie](https://github.com/pixie-labs/pixie) - Live-debug multi-cluster K8s environments without changing code and moving data off-cluster.
+* [Qovery](https://www.qovery.com) - Enterprise Kubernetes management platform for deploying applications via self-service workflows. Supports EKS, GKE, AKS, and Scaleway. Includes a [Terraform provider](https://registry.terraform.io/providers/Qovery/qovery/latest/docs), CLI, API, and an [AI Agent Skill](https://github.com/Qovery/qovery-skills) for deploying from AI coding tools.
 * [KubeEdge](https://kubeedge.io) - An open platform to enable Edge computing
 * [k8s-image-swapper](https://github.com/estahn/k8s-image-swapper) - Mirror images into your own registry and swap image references automatically.
 * [configurator](https://github.com/gopaddle-io/configurator) - A version control and a sync service that keeps Kubernetes ConfigMaps and Secrets in sync with the deployment.


### PR DESCRIPTION
Adds [Qovery](https://www.qovery.com) to the Related Software section.

Qovery is an enterprise Kubernetes management platform that helps teams deploy applications through safe, self-service workflows on AWS EKS, GCP GKE, Azure AKS, and Scaleway Kapsule.

It includes:
- A [Terraform provider](https://registry.terraform.io/providers/Qovery/qovery/latest/docs) for infrastructure as code
- A CLI for terminal-based management
- A REST API
- An [AI Agent Skill](https://github.com/Qovery/qovery-skills) that works with Claude Code, Cursor, OpenCode, and 30+ AI coding tools to deploy applications from source code

Website: https://www.qovery.com
GitHub: https://github.com/Qovery