### PR TITLE
Add YAML Validator to YAML/JSON Config section

### DIFF
--- a/docs/projects/projects.md
+++ b/docs/projects/projects.md
@@ -501,6 +501,7 @@ Projects
 * [kubegen](https://github.com/errordeveloper/kubegen) - Reduces the verbosity of Kubernetes resource definitions, and adds macros for templating
 * [kubeval](https://github.com/garethr/kubeval) - CLI tool for validating a Kubernetes YAML or JSON configuration file
 * [KubeQ](https://kubeq.click) - A fast, simple, and powerful web-based Kubernetes manifest validator. No installation or config needed—just paste your manifest and get instant feedback on quality, security, and best practices. Powered by kubeval, kube-score, and kubeaudit. Great for pre-commit validation, reviewing charts, teaching, and CI/CD linting.
+* [YAML Validator](https://yamlvalidator.dev), [(chrome extension)](https://chromewebstore.google.com/detail/yaml-validator/gjgbohnlhijomhfiflapnlnmcpckgigg) - Online YAML validator, formatter and viewer with built-in Kubernetes JSON Schema validation. The Chrome extension also adds YAML code folding on GitHub.
 * [helmify](https://github.com/arttor/helmify) - CLI tool to convert K8s YAMLs into a Helm chart
 
 ## Static Analysis


### PR DESCRIPTION
Hi! 👋

Adding [YAML Validator](https://yamlvalidator.dev) to the **YAML/JSON Config** section in `docs/projects/projects.md`.

**YAML Validator** is an online YAML validator, formatter and viewer with built-in Kubernetes JSON Schema validation. The [Chrome extension](https://chromewebstore.google.com/detail/yaml-validator/gjgbohnlhijomhfiflapnlnmcpckgigg) also adds YAML code folding on GitHub — handy when reviewing large K8s manifests.

Thanks for maintaining this awesome list!