### PR TITLE
feat: add KubeStellar Console to UI section

### DIFF
--- a/docs/projects/projects.md
+++ b/docs/projects/projects.md
@@ -314,6 +314,7 @@ Projects
 * [KubeHelper](https://github.com/KubeHelper/kubehelper) - KubeHelper - simplifies many daily Kubernetes cluster tasks through a web interface.
 * [Portainer](https://github.com/portainer/portainer) - Containerized web-based UI for managing for Docker, Docker Swarm and Kubernetes environments.
 * [CyclopsUI](https://github.com/cyclops-ui/cyclops) - Dynamically rendered UI for Kubernetes resources based on Helm templating engine
+* [KubeStellar Console](https://github.com/kubestellar/console) - AI-powered multi-cluster Kubernetes dashboard with CNCF project integrations, real-time observability, and guided install missions across edge and cloud clusters.
 
 ## Desktop applications
 


### PR DESCRIPTION
## What

Adds **KubeStellar Console** to the UI/Dashboards section in `docs/projects/projects.md`, after the existing CyclopsUI entry.

## Why

KubeStellar Console is a CNCF Sandbox project — an AI-powered multi-cluster Kubernetes dashboard with:
- Real-time observability across edge, cloud, and hybrid clusters
- CNCF project integrations: Argo, Kyverno, Istio, and 20+ others
- AI/LLM-powered operations and natural language cluster queries
- GitHub: https://github.com/kubestellar/console
- Live demo: https://console.kubestellar.io

## Entry added

```markdown
* [KubeStellar Console](https://github.com/kubestellar/console) - AI-powered multi-cluster Kubernetes dashboard with real-time observability, CNCF project integrations, and edge/cloud cluster management.
```