### PR TITLE
Add KubeStellar Console to Web applications section

### DIFF
--- a/docs/projects/projects.md
+++ b/docs/projects/projects.md
@@ -312,6 +312,7 @@ Projects
 * [Kubevious](https://github.com/kubevious/kubevious) - An open source UI to make Kubernetes configuration and state obvious and safe.
 * [Octant](https://github.com/vmware-tanzu/octant) - A web-based, highly extensible platform for developers to better understand the complexity of Kubernetes clusters.
 * [KubeHelper](https://github.com/KubeHelper/kubehelper) - KubeHelper - simplifies many daily Kubernetes cluster tasks through a web interface.
+* [KubeStellar Console](https://github.com/kubestellar/console) - AI-powered multi-cluster Kubernetes dashboard with real-time observability, 150+ cards, and 30+ CNCF integrations.
 * [Portainer](https://github.com/portainer/portainer) - Containerized web-based UI for managing for Docker, Docker Swarm and Kubernetes environments.
 * [CyclopsUI](https://github.com/cyclops-ui/cyclops) - Dynamically rendered UI for Kubernetes resources based on Helm templating engine
 


### PR DESCRIPTION
Adds [KubeStellar Console](https://github.com/kubestellar/console) to the **Web applications** section.

KubeStellar Console is an open-source, AI-powered multi-cluster Kubernetes dashboard with:
- 150+ dashboard cards for real-time observability
- Integrations with 30+ CNCF projects (Prometheus, Istio, ArgoCD, etc.)
- 15 themes, 10 locale support, WebSocket live updates
- Built with React + TypeScript + Go (Fiber)
- Apache-2.0 licensed, CNCF Sandbox project (under KubeStellar)

🔗 Live demo: https://console.kubestellar.io
📦 Source: https://github.com/kubestellar/console