### PR TITLE
Add Ownkube to Application deployment orchestration

### DIFF
--- a/docs/projects/projects.md
+++ b/docs/projects/projects.md
@@ -379,6 +379,7 @@ Projects
 * [Skaffold](https://github.com/GoogleCloudPlatform/skaffold) - Command line tool that facilitates continuous development for Kubernetes applications.
 * [kubedog](https://github.com/flant/kubedog) - Kubedog is a library and cli utility that allows watching and following kubernetes resources in CI/CD deploy pipelines.
 * [kapp](https://github.com/k14s/kapp) - simple deployment tool focused on the concept of "Kubernetes application" — a set of resources with the same label
+* [Ownkube](https://ownkube.io) - AI-enabled developer platform that runs in your own AWS account on k3s or EKS. Git push to deploy, managed Postgres, preview environments per PR, and AI error detection from day one.
 
 ## Configuration
 


### PR DESCRIPTION
Adds [Ownkube](https://ownkube.io) under **Application deployment orchestration**.

Ownkube is a developer platform that runs in the user's own AWS account on top of k3s (single-node) or EKS (multi-node). It gives teams a Heroku-style developer experience (git push, preview environments, managed Postgres, AI error detection) on Kubernetes infrastructure they own. Free for teams on single-node k3s; usage-based on EKS multi-node ($10/vCPU + $5/GB RAM per month). Compatible with AWS Activate credits, no markup on compute.

Why it fits this section:
- Git push to deploy onto Kubernetes (similar to Gitkube already listed)
- Application-level deployment + rollback orchestration
- Targets the K8s-on-AWS workflow specifically

Note: Ownkube is a hosted SaaS control plane, not a public open-source repo, so the 25-star/3-contributor criterion in CRITERIA_OF_SUBMISSION applies only loosely. Several existing entries in this list link to commercial sites (Bitnami Production Runtime, IBM UrbanCode, Cloudsmith, Pixie, etc.) so the precedent for hosted-platform entries is established.