### PR TITLE
Add Fortem: AI-native self-hosted Kubernetes IDP

### DIFF
--- a/docs/projects/projects.md
+++ b/docs/projects/projects.md
@@ -18,6 +18,7 @@ Projects
 * [Fairwinds Pluto](https://github.com/FairwindsOps/pluto) - A cli tool to help discover deprecated apiVersions in Kubernetes
 * [Fairwinds Polaris](https://github.com/reactiveops/polaris) - An open source dashboard for Kubernetes best practices
 * [Fission Workflows](https://github.com/fission/fission-workflows) - Workflow-based serverless function composition
+* [Fortem](https://fortem.dev) - AI-native Internal Developer Platform for Kubernetes — self-hosted Helm chart install, NL-to-manifest generation, AIOps cost optimization, Kubernetes Operator architecture
 * [Forecastle](https://github.com/stakater/Forecastle) - A dashboard which dynamically discovers and provides a launchpad to access applications deployed on Kubernetes
 * [Gefyra](https://github.com/gefyrahq/gefyra) - Connect Docker containers to any Kubernetes environment
 * [Getdeck](https://github.com/Getdeck/getdeck) - A CLI that creates reproducible Kubernetes environments for development and testing


### PR DESCRIPTION
## What is Fortem?

**[Fortem](https://fortem.dev)** is an AI-native Internal Developer Platform for Kubernetes — built for engineering teams who need full IDP capabilities without the overhead of a dedicated platform team.

**Key characteristics:**
- **Self-hosted** — single Helm chart install inside your cluster; no external SaaS dependency
- **Kubernetes Operator architecture** — environment state declared as CRDs, reconciled continuously, fully GitOps-compatible
- **AI-native** — NL-to-K8s manifest generation, AIOps idle detection ($180+/mo saved per idle env), incident diagnosis, right-sizing engine
- **Zero vendor lock-in** — every Fortem object is a standard K8s CRD exportable via `kubectl get`
- **Multi-cluster federation** — single pane of glass across all clusters

Added to the **Related Software** section, alphabetically between *Fission Workflows* and *Forecastle*.

**Links:** [fortem.dev](https://fortem.dev) · [Docs](https://fortem.dev/docs)
