### PR TITLE
Add Radar to Web applications

### DIFF
--- a/docs/projects/projects.md
+++ b/docs/projects/projects.md
@@ -319,6 +319,7 @@ Projects
 * [Portainer](https://github.com/portainer/portainer) - Containerized web-based UI for managing for Docker, Docker Swarm and Kubernetes environments.
 * [CyclopsUI](https://github.com/cyclops-ui/cyclops) - Dynamically rendered UI for Kubernetes resources based on Helm templating engine
 * [KubeStellar Console](https://github.com/kubestellar/console) - AI-powered multi-cluster Kubernetes dashboard with CNCF project integrations, real-time observability, and guided install missions across edge and cloud clusters.
+* [Radar](https://github.com/skyhook-io/radar) - Modern Kubernetes visibility - watch-based real-time UI with multi-cluster topology, event timeline, image filesystem viewer, Helm and GitOps management (FluxCD/ArgoCD), and a built-in MCP server for AI agents. Single binary or native desktop app (macOS/Linux/Windows). No agents, no cloud dependency. Apache 2.0.
 
 ## Desktop applications
 


### PR DESCRIPTION
Adds Radar to the Web applications section.

**Project:** [Radar](https://github.com/skyhook-io/radar)

Modern open-source Kubernetes visibility tool. Watch-based real-time UI with multi-cluster topology, event timeline, image filesystem viewer, Helm and GitOps management (FluxCD/ArgoCD), and a built-in MCP server for AI agents. Single binary, no agents, no cloud dependency.

**Meets the contributor requirements:**
- ⭐ 1,300+ GitHub stars
- 👥 17+ contributors
- 📚 [Full documentation](https://radarhq.io/docs)
- 📜 Apache-2.0 licensed