### PR TITLE
Add DevOps Mastery Curriculum - Kubernetes module to tutorials

### DIFF
--- a/docs/learning-resources/courses.md
+++ b/docs/learning-resources/courses.md
@@ -18,3 +18,4 @@ MOOC Courses / Tutorials
   - [Imperative vs. Declarative — a Kubernetes Tutorial](https://medium.com/payscale-tech/imperative-vs-declarative-a-kubernetes-tutorial-4be66c5d8914) by [Adrien Trouillaud](https://github.com/adrienjt/)
   - [Learning Kubernetes, The Chinese Taoist Way](https://github.com/caicloud/kube-ladder)
   - [Hands-on tutorials on cloud and cloud native technologies](https://docs.meshery.io/guides/tutorials)
+  - [DevOps Mastery Curriculum - Kubernetes Module](https://github.com/Kuldeep2822k/devops-mastery-curriculum) - Production-grade, local-first Kubernetes module with break/fix labs (ImagePullBackOff, OOMKilled, probe failures), debugging playbooks, troubleshooting scenarios, runbooks, and ADR templates. Part of a 25-module zero-to-staff-engineer curriculum.


### PR DESCRIPTION
## What this adds

[DevOps Mastery Curriculum — Kubernetes Module](https://github.com/Kuldeep2822k/devops-mastery-curriculum) — a hands-on, production-grade Kubernetes learning module within a broader 25-module zero-to-staff-engineer curriculum.

**Why it belongs in Tutorials:**
- Module 06 focuses on Kubernetes: workload patterns, networking, storage, scheduling, and deep debugging
- Includes break/fix labs with real failure modes: ImagePullBackOff, label mismatches, readiness probe failures, OOMKilled
- Every lab has: Goal → Setup → Steps → Verify → Cleanup → Troubleshooting sections
- Includes runbook templates (service 503 decision tree, image pull checklist, OOMKilled tuning guide)
- Local-first using kind or minikube — no cloud account required

Added to the **Tutorials** section under MOOC Courses / Tutorials.