### PR TITLE
Add Kzmlabs StateFun Actors

### DIFF
--- a/docs/projects/projects.md
+++ b/docs/projects/projects.md
@@ -47,6 +47,7 @@ Projects
 * [k8s-image-swapper](https://github.com/estahn/k8s-image-swapper) - Mirror images into your own registry and swap image references automatically.
 * [configurator](https://github.com/gopaddle-io/configurator) - A version control and a sync service that keeps Kubernetes ConfigMaps and Secrets in sync with the deployment.
 * [KubeDiagrams](https://github.com/philippemerle/KubeDiagrams) - A command-line tool to generate Kubernetes architecture diagrams from Kubernetes manifest files, kustomization files, Helm charts, and actual cluster state.
+* [Kzmlabs StateFun Actors](https://github.com/kzmlabs/flink-statefun) - Stateful actor framework deployable on Kubernetes via the Apache Flink Operator. Durable per-key state, exactly-once messaging, Kafka & Kinesis I/O. Continues Apache Stateful Functions on Flink 2.x + Java 21.
 
 ## Package Managers
 


### PR DESCRIPTION
Adding Kzmlabs StateFun Actors under Related Software. It's a stateful actor framework that ships as a container image (ghcr.io/kzmlabs/flink-statefun) and deploys on Kubernetes via the Apache Flink Operator.

Continues the Apache Stateful Functions programming model on the modern Flink line (Flink 2.2 + Java 21). The repo includes a kind-based end-to-end test that provisions Flink Operator + Kafka + LocalStack and runs both Kafka and Kinesis ingress paths against a real Flink cluster on every release so the K8s deployment story is exercised in CI on each release. Apache 2.0.

https://github.com/kzmlabs/flink-statefun