### PR TITLE
Add PlatformCon and Platform Engineering University

### DIFF
--- a/docs/extras/conferences.md
+++ b/docs/extras/conferences.md
@@ -10,3 +10,4 @@ Conferences
 * [Docker Con](http://dockercon.com)
 * [GCP Next](http://cloudnext.withgoogle.com/)
 * [Kubecon](http://events.linuxfoundation.org/events/kubecon)
+* [PlatformCon](https://platformcon.com) (the world's largest platform engineering conference)

--- a/docs/learning-resources/courses.md
+++ b/docs/learning-resources/courses.md
@@ -9,6 +9,7 @@ MOOC Courses / Tutorials
   - [Introduction to Kubernetes at edX](http://www.edx.org/course/introduction-kubernetes-linuxfoundationx-lfs158x)
   - [(Classpert) A list of free and paid Kubernetes courses from popular e-learning platforms](https://classpert.com/search/kubernetes)
   - [Complete Kubernetes Course in French (Free)](https://blog.stephane-robert.info/docs/conteneurs/orchestrateurs/kubernetes/) - A free and complete Kubernetes course in French covering core concepts, advanced usage, and practical examples.
+  - [Platform Engineering University](https://university.platformengineering.org) - Platform engineering courses and certifications
 
   ### [Tutorials](#tutorials)
 


### PR DESCRIPTION
Adds two platform engineering learning resources:

- [PlatformCon](https://platformcon.com) – the world's largest platform engineering conference (conferences.md)
- [Platform Engineering University](https://university.platformengineering.org) – platform engineering courses and certifications (courses.md)