### PR TITLE
Add mirrord

### DIFF
--- a/docs/projects/projects.md
+++ b/docs/projects/projects.md
@@ -37,6 +37,7 @@ Projects
 * [Kubernetes Ec2 Autoscaler](https://github.com/openai/kubernetes-ec2-autoscaler)
 * [Kubic-Project](https://github.com/kubic-project)
 * [Meshery](https://meshery.io) - Cloud native management plane for Kubernetes infrastructure and applications. CNCF Sandbox project.
+* [mirrord](https://metalbear.com/mirrord/) - Develop locally against a remote Kubernetes cluster without deploying or mocking.
 * [Reloader](https://github.com/stakater/Reloader) - Auto-load updates of ConfigMaps and Secrets into pods for Deployments, StatefulSets and DaemonSets
 * [Telepresence](http://www.telepresence.io) - Locally develop/debug services against a remote Kubernetes cluster
 * [krane](https://github.com/Shopify/krane) - A command-line tool that helps you ship changes to a Kubernetes namespace and understand the result


### PR DESCRIPTION
Adds mirrord to the Related Software section.

mirrord lets developers run local services as if they were running inside a remote Kubernetes cluster, with no deploys and no mocking. Open source under MIT, with a commercial Operator for team-scale concurrent shared-cluster development (queue splitting, database branching, RBAC, concurrent steal-with-filter).

Meets the submission requirements:
- 5,059 stars
- 57 contributors
- Docs at https://metalbear.com/mirrord/docs

Inserted alphabetically between Meshery and Reloader. The Related Software section already lists Telepresence and Gefyra, which mirrord is most similar to.