### PR TITLE
Add kbu — Kubernetes TUI

### DIFF
--- a/docs/projects/projects.md
+++ b/docs/projects/projects.md
@@ -370,6 +370,7 @@ Projects
 * [Portainer](https://github.com/portainer/portainer) - Secure REST API proxy to Kubernetes environments, enabling integrations with external tools.
 * [kubernetes-el](https://github.com/kubernetes-el/kubernetes-el) - Kubernetes client for Emacs
 * [lfk](https://github.com/janosmiko/lfk) - Yazi-inspired, vim-like keyboard focused Lightning Fast Kubernetes navigator.
+* [km8](https://github.com/vulcanshen/km8) - A lightweight terminal UI for Kubernetes management with vim-style navigation, CRD support, and log streaming.
 
 ## Application deployment orchestration
 


### PR DESCRIPTION
## Add kbu to API/CLI adaptors section

[kbu](https://github.com/vulcanshen/kbu) is a single-pane Kubernetes TUI built
with Go and Bubble Tea. Four keys — `Tab` / `Space` / `Enter` / `Esc` — drive
the entire tool; `Space` opens a contextual "what can I do here?" menu on every
panel, so there are no hotkeys to memorize and no setup.

**Highlights:**
- **Relatives navigation** — jump between a resource and everything related to
  it (Deployment ⇄ Pods ⇄ ReplicaSet, Ingress ⇄ Service, …)
- **Side-by-side YAML compare** — diff any two resources
- **Embedded persistent shell** — a real terminal pane inside the TUI; any
  kubectl / helm workflow you trust rides along
- **Helm as a first-class resource** — browse releases, values, and history
- **Live edit** via the Space menu (kubectl edit), log streaming, container exec
- CRD support via dynamic discovery + real-time Watch updates
- Full mouse support (click / double-click drill / right-click menu / wheel)

> Note: this project was previously named **km8** (v1.7.x and earlier); it was
> renamed to **kbu** as of v2.0.0. The old repository URL redirects.
