### PR TITLE
Add Attune - in-place pod resource right-sizing operator

### DIFF
--- a/docs/projects/projects.md
+++ b/docs/projects/projects.md
@@ -10,6 +10,7 @@ Projects
 
 * [Ambassador](http://www.getambassador.io) - API Gateway built on the Envoy Proxy
 * [Argo](https://github.com/argoproj/argo) - The Workflow Engine for Kubernetes
+* [Attune](https://github.com/attune-io/attune) - Kubernetes operator for safe, in-place pod resource right-sizing using real Prometheus metrics. VPA replacement.
 * [Bitnami Kubernetes Production Runtime](https://kubeprod.io)
 * [Capact](https://github.com/capactio/capact) - A framework to manage applications and infrastructure in a unified way
 * [Client Libraries](https://github.com/kubernetes/website/blob/master/content/en/docs/reference/using-api/client-libraries.md)


### PR DESCRIPTION
## Add Attune

[Attune](https://github.com/attune-io/attune) is a Kubernetes operator for safe, in-place pod resource right-sizing using real Prometheus metrics. It serves as a modern VPA replacement, resizing pods in place without restarts (leveraging Kubernetes 1.32+ In-Place Pod Resize).

**Why it belongs here:** Attune fits alongside existing autoscaling and resource management tools in the Related Software section (Escalator, KEDA, etc.). It is open source under the Apache 2.0 license, actively maintained, and solves a common Kubernetes operational challenge — keeping resource requests aligned with actual usage.

Added in alphabetical order in the Related Software section.