### PR TITLE
Add groundcover to Monitoring Services

### DIFF
--- a/docs/projects/projects.md
+++ b/docs/projects/projects.md
@@ -66,6 +66,7 @@ Projects
 * [eventrouter](https://github.com/heptiolabs/eventrouter) - simple introspective kubernetes service that forwards events to a specified sink.
 * [Goldpinger](https://github.com/bloomberg/goldpinger) display, monitor and alert on inter-cluster connectivity
 * [Grafana Kubernetes App](https://github.com/grafana/kubernetes-app)
+* [groundcover](https://www.groundcover.com/) - eBPF-based observability platform for Kubernetes with logs, metrics, traces, and APM; deployed inside the user's own cloud (BYOC).
 * [Heapster](https://github.com/kubernetes/heapster)
 * [HolmesGPT](https://github.com/robusta-dev/holmesgpt) - On-Call/DevOps Assistant - Get a head start on fixing alerts with AI. Investigate Prometheus alerts, Jira/Pagerduty/Opsgenie tickets automatically.
 * [Instana](https://www.instana.com/) - Automatic Kubernetes Application Performance Monitoring


### PR DESCRIPTION
Adds groundcover to docs/projects/projects.md → Monitoring Services.

groundcover is a commercial eBPF-based observability platform for Kubernetes — a single DaemonSet sensor captures logs, metrics, traces, and APM across the cluster without per-pod instrumentation. Same category as the existing eBPF entries Alaz and Ingero, and overlaps with Datadog / Dynatrace / Instana / New Relic / Sysdig already in the section. The BYOC differentiator (data plane runs inside the customer's own cloud) is the angle that distinguishes it from the SaaS competitors listed.

Inserted alphabetically between Grafana Kubernetes App and Heapster.

Disclosure: I work at groundcover.