### PR TITLE
Add Klustr to Desktop applications

### DIFF
--- a/docs/projects/projects.md
+++ b/docs/projects/projects.md
@@ -331,6 +331,7 @@ Projects
 * [K8Studio](https://github.com/guiqui/k8Studio) - K8Studio is a cross-platform client IDE to manage Kubernetes Clusters.
 * [KFtray](https://github.com/hcavarsan/kftray) - Manage and run multiple kubectl port-forward configurations directly in the menu bar, syncing configurations with git repositories.
 * [Kunobi](https://kunobi.ninja) - Kubernetes desktop IDE with an embedded MCP server, providing visual oversight of AI-driven cluster operations. Supports FluxCD, ArgoCD, Helm, and expanding to infrastructure beyond Kubernetes.
+* [Klustr](https://github.com/SametKUM/klustr) - A native (non-Electron) cross-platform Kubernetes desktop client driven purely by your kubeconfig. Multi-context live resource views, logs, exec, port-forwarding, full RBAC, CRDs, Helm, Argo CD, Flux CD and Gateway API support, with nothing installed in the cluster.
 
 ## Mobile applications
 


### PR DESCRIPTION
### What is it?
**[Klustr](https://github.com/SametKUM/klustr)** — a native (non-Electron, Wails/Go + React) cross-platform Kubernetes **desktop application**. Added to the *Desktop applications* section next to Lens, Aptakube and K8Studio.

### What is it for?
A pure Kubernetes client that drives the standard Kubernetes API using only the user's `~/.kube/config` — **nothing is installed in the cluster**. It handles multi-cluster day-to-day operations from a single window:
- Multi-context aggregated views, live (informer-backed, no polling) resource lists, logs, exec, port-forwarding, full RBAC browsing.
- First-class **CRD**, **Helm v3**, **Argo CD**, **Flux CD** and **Gateway API** integrations built in — no vendor CLIs shelled out.

### Submission requirements
- **25+ GitHub Stars** — ✅ 26 and growing.
- **Proper documentation** — ✅ README with feature overview, screenshots and install instructions; ships Homebrew cask, AUR package and release binaries for macOS and Linux.
- **Actively maintained** — ✅ frequent commits and tagged releases, MIT-licensed.

A stable, usable client that ships tagged releases today — a strong fit for the Desktop applications section.