### PR TITLE
Add platform-skills — AI field handbook for platform engineers

### DIFF
--- a/docs/projects/projects.md
+++ b/docs/projects/projects.md
@@ -43,6 +43,7 @@ Projects
 * [ktunnel](https://github.com/omrikiei/ktunnel) - A command-line tool that establishes a reverse tunnel between Kubernetes and your cluster, use it to locally develop/debug services or integrate with local resources.
 * [k8s-platform-lcm](https://github.com/arminc/k8s-platform-lcm) - A faster and easier way to manage the lifecycle of applications and tools, running and living around your Kubernetes platform
 * [Pixie](https://github.com/pixie-labs/pixie) - Live-debug multi-cluster K8s environments without changing code and moving data off-cluster.
+* [platform-skills](https://github.com/nitinjain999/platform-skills) - Production-grade field handbook for platform engineers covering Kubernetes, Flux CD, Terraform, GitHub Actions, AWS, and more. Works as a Claude, Codex, Cursor, and Copilot plugin with blast radius, validation steps, and rollback plans built in.
 * [KubeEdge](https://kubeedge.io) - An open platform to enable Edge computing
 * [k8s-image-swapper](https://github.com/estahn/k8s-image-swapper) - Mirror images into your own registry and swap image references automatically.
 * [configurator](https://github.com/gopaddle-io/configurator) - A version control and a sync service that keeps Kubernetes ConfigMaps and Secrets in sync with the deployment.


### PR DESCRIPTION
## Description

Adds [platform-skills](https://github.com/nitinjain999/platform-skills) to the Related Software section.

platform-skills is a free, open-source field handbook for platform engineers covering Kubernetes, Flux CD, Terraform, GitHub Actions, AWS, OPA/Rego, KEDA, supply chain security, and 30+ more domains. It works as a Claude, Codex, Cursor, and Copilot plugin — giving engineers interactive guidance with blast radius analysis, validation commands, and rollback plans built in.

## Checklist

- [x] Entry is alphabetically placed (after Pixie, before Reloader)
- [x] Description is concise and accurate
- [x] Link points to the correct GitHub repo
- [x] No trailing period (following list conventions)