### PR TITLE
Add OpenRun to projects

### DIFF
--- a/docs/projects/projects.md
+++ b/docs/projects/projects.md
@@ -163,6 +163,7 @@ Projects
 * [Werf](https://werf.io) - GitOps tool with advanced features to build images and deploy them to Kubernetes. Integrates with any existing CI system.
 * [Buddy](https://buddy.works)
 * [PipeCD](https://pipecd.dev/) - Continuous Delivery for Declarative Kubernetes, Serverless and Infrastructure Applications
+* [OpenRun](https://github.com/openrundev/openrun) - Declarative app deployment platform for internal tools, on single-node or Kubernetes.
 
 ## Serverless Implementations
 


### PR DESCRIPTION
Adds OpenRun under Projects > Continuous Delivery.

OpenRun is an Apache-2.0 licensed app deployment platform for internal tools. It supports declarative GitOps-style app deployment and can deploy on a single node with Docker/Podman or onto a Kubernetes cluster.

Project submission notes:
- GitHub project link is used as the item link
- Description is concise and on the same line
- OpenRun has documentation at openrun.dev
- OpenRun appears to meet the project criteria for stars and documentation