### PR TITLE
Add ZopNight to Monitoring Services

### DIFF
--- a/docs/projects/projects.md
+++ b/docs/projects/projects.md
@@ -107,6 +107,7 @@ Projects
 * [kube-eventer](https://github.com/AliyunContainerService/kube-eventer) - kube-eventer emit kubernetes events to sinks (kafka, slack, webhook, etc)
 * [VictoriaMetrics](https://docs.victoriametrics.com/) - VictoriaMetrics: fast, cost-effective monitoring solution and time series database.
 * [VictoriaLogs](https://docs.victoriametrics.com/victorialogs/) - VictoriaLogs is a fast and easy-to-use, open source logs solution. Highly scalable on cloud, kubernetes or on-premise setups.
+* [ZopNight](https://zopnight.com/) - Kubernetes-native FinOps autopilot for AWS, GCP, Azure. Namespace-level scheduling, scale-to-zero, idle resource detection.
 
 ## Testing
 


### PR DESCRIPTION
Adds **Zopnight** to `docs/projects/projects.md`.

Zopnight is a cloud cost and infrastructure governance platform for AWS, Azure and GCP: cost allocation by provider, resource, tag and team, budgets and spend tracking, rightsizing and idle-resource recommendations, and resource scheduling. It also ships a first-party remote MCP server, so the same data can be queried from an AI assistant. On Kubernetes specifically it covers namespace-level scheduling, scale-to-zero and idle-resource detection across EKS, GKE and AKS.

The entry uses the surrounding `* [Name](url) - Description.` format.

**Links**

- server link - https://api.zop.dev/mcp-server
- learn doc - https://zop.dev/learn/mcp-server
- claude learn - https://zop.dev/learn/how-to/set-up-zopnight-mcp-for-claude

Disclosure: I work on Zopnight.