### PR TITLE
Add Radar

### DIFF
--- a/docs/projects/projects.md
+++ b/docs/projects/projects.md
@@ -91,6 +91,7 @@ Projects
 * [NexClipper](https://github.com/NexClipper/NexClipper) - An open source software for monitoring Kubernetes and containers.
 * [Outcold Solutions](https://www.outcoldsolutions.com) - monitoring Kubernetes, OpenShift and Docker in Splunk Enterprise and Splunk Cloud (metrics and log forwarding)
 * [Prometheus](http://prometheus.io)
+* [Radar](https://github.com/skyhook-io/radar) - Local-first Kubernetes visibility with topology, event timeline, service traffic, resource browsing, Helm management, GitOps workflows, and built-in MCP for AI assistants.
 * [Replex.io](https://replex.io) - Kubernetes Governance & Cost Control.
 * [Robusta.dev](https://github.com/robusta-dev/robusta) - Better Prometheus Alerts for Kubernetes with ability to Enrich, Group, and Remediate your Alerts.
 * [Searchlight](https://github.com/appscode/searchlight)

--- a/docs/projects/projects.md
+++ b/docs/projects/projects.md
@@ -319,6 +319,7 @@ Projects
 * [Portainer](https://github.com/portainer/portainer) - Containerized web-based UI for managing for Docker, Docker Swarm and Kubernetes environments.
 * [CyclopsUI](https://github.com/cyclops-ui/cyclops) - Dynamically rendered UI for Kubernetes resources based on Helm templating engine
 * [KubeStellar Console](https://github.com/kubestellar/console) - AI-powered multi-cluster Kubernetes dashboard with CNCF project integrations, real-time observability, and guided install missions across edge and cloud clusters.
+* [Radar](https://github.com/skyhook-io/radar) - Local-first Kubernetes visibility with topology, event timeline, service traffic, resource browsing, Helm management, GitOps workflows, and built-in MCP for AI assistants.
 
 ## Desktop applications
 


### PR DESCRIPTION
Adds Radar to the Web applications section. Radar is a local-first Kubernetes visibility tool with topology, event timeline, service traffic, resource browsing, Helm management, GitOps workflows, and built-in MCP for AI assistants.

Validation: attempted `make test`, but the repo Makefile tries to install `awesome_bot` into system Ruby gems under `/Library/Ruby/Gems/2.6.0` and failed with `Gem::FilePermissionError`.