### PR TITLE
Add selenosis to projects list

### DIFF
--- a/docs/projects/projects.md
+++ b/docs/projects/projects.md
@@ -133,7 +133,8 @@ Projects
 * [KubePug](https://github.com/rikatz/kubepug) - Kubernetes Pre-Upgrade Checker
 * [KubeLibrary](https://github.com/devopsspiral/KubeLibrary) - RobotFramework library for testing Kubernetes cluster
 * [Speedscale](https://speedscale.com/kubernetes/) - Speedscale is a traffic replay framework that simulates production conditions, so you can validate changes quickly and easily.
-* [Stoat](https://docs.stoat.dev/) - Stoat helps you access and browse logs for Kubernetes tests run on GitHub actions 
+* [Stoat](https://docs.stoat.dev/) - Stoat helps you access and browse logs for Kubernetes tests run on GitHub actions
+* [selenosis](https://github.com/alcounit/selenosis) - Stateless Kubernetes-native hub that routes Selenium, Playwright, and MCP sessions to on-demand browser pods via custom resources.
 
 ## Continuous Delivery
 


### PR DESCRIPTION
Add [selenosis](https://github.com/alcounit/selenosis) to the list.

Selenosis is a Kubernetes-native, stateless alternative to Selenium Grid. Each WebDriver session is provisioned as a dedicated, ephemeral pod (one session = one pod) — no warm pools and no shared browsers. It also supports Playwright and MCP.

Sessions are modeled as Kubernetes custom resources. A Browser resource represents a single browser session (browser name and version) and is reconciled into a pod, while a BrowserConfig resource defines the browser images and pod templates, with a deterministic merge order (version → browser → template). This makes browser provisioning declarative, with Kubernetes as the single source of truth.