### PR TITLE
Add freelens-pod-filebrowser to Debug section

### DIFF
--- a/docs/projects/projects.md
+++ b/docs/projects/projects.md
@@ -547,6 +547,7 @@ Projects
 ## Debug
 
 * [Kubectl-Debug](https://github.com/aylei/kubectl-debug)
+* [freelens-pod-filebrowser](https://github.com/masoudei/freelens-pod-filebrowser) - Browse, view, edit, upload, and delete files inside Kubernetes pod containers directly from the Freelens UI.
 * [mirrord](https://github.com/metalbear-co/mirrord) - Connect your local process and your k8s cluster, letting you run local code in cloud conditions. 
 
 ## Benchmark Tools


### PR DESCRIPTION
## Summary

Add [freelens-pod-filebrowser](https://github.com/masoudei/freelens-pod-filebrowser) to the Debug section.

## Description

freelens-pod-filebrowser is a Freelens extension that lets you browse, view, edit, upload, and delete files inside Kubernetes pod containers — directly from the Freelens UI. It eliminates the need to run \kubectl exec\ repeatedly for debugging configs, inspecting logs, or fixing containers.

## Checklist
- [x] I have read the [Contributing Guide](https://github.com/ramitsurana/awesome-kubernetes/blob/master/docs/guidelines/CONTRIBUTING.md)
- [x] The item is placed in the correct section
- [x] The item follows the existing format (\* [Name](url) - Description\)