### PR TITLE
docs: add KubeStellar to Related Software section

### DIFF
--- a/docs/projects/projects.md
+++ b/docs/projects/projects.md
@@ -43,6 +43,7 @@ Projects
 * [krane](https://github.com/Shopify/krane) - A command-line tool that helps you ship changes to a Kubernetes namespace and understand the result
 * [ktunnel](https://github.com/omrikiei/ktunnel) - A command-line tool that establishes a reverse tunnel between Kubernetes and your cluster, use it to locally develop/debug services or integrate with local resources.
 * [k8s-platform-lcm](https://github.com/arminc/k8s-platform-lcm) - A faster and easier way to manage the lifecycle of applications and tools, running and living around your Kubernetes platform
+* [KubeStellar](https://github.com/kubestellar/kubestellar) - Multi-cluster configuration management for edge and hybrid cloud Kubernetes environments. CNCF Sandbox project.
 * [Pixie](https://github.com/pixie-labs/pixie) - Live-debug multi-cluster K8s environments without changing code and moving data off-cluster.
 * [KubeEdge](https://kubeedge.io) - An open platform to enable Edge computing
 * [k8s-image-swapper](https://github.com/estahn/k8s-image-swapper) - Mirror images into your own registry and swap image references automatically.


### PR DESCRIPTION
KubeStellar is a CNCF Sandbox project for multi-cluster configuration management across edge and hybrid cloud Kubernetes environments.

#### Requirements checklist
- Minimum 25 GitHub Stars — KubeStellar has 682+ stars
- Minimum 3+ contributors — active contributor community
- Proper documentation — https://docs.kubestellar.io

#### Note
Only the KubeStellar Console was previously listed (under Web Applications). This adds KubeStellar itself ,the core multi-cluster management tool to the Related Software section where it belongs.